### PR TITLE
Add flow cutter contraction plan function

### DIFF
--- a/bin/prepare_rqc_simulation_files.jl
+++ b/bin/prepare_rqc_simulation_files.jl
@@ -26,7 +26,7 @@ function parse_commandline(ARGS)
             help = "Number of amplitudes"
             default = nothing
         "--seed"
-            help = "Seed to use for both circuit generation and contraction planning"
+            help = "Seed to use for circuit generation, contraction planning and selecting amplitudes to compute."
             default = nothing
         "--decompose"
             help = "Set if two qubit gates should be decomposed."

--- a/bin/prepare_rqc_simulation_files.jl
+++ b/bin/prepare_rqc_simulation_files.jl
@@ -26,7 +26,7 @@ function parse_commandline(ARGS)
             help = "Number of amplitudes"
             default = nothing
         "--seed"
-            help = "Seed to use for both circuit and amplitude selection"
+            help = "Seed to use for both circuit generation and contraction planning"
             default = nothing
         "--decompose"
             help = "Set if two qubit gates should be decomposed."
@@ -82,8 +82,6 @@ function main(ARGS)
     decompose = parsed_args["decompose"]
     hypergraph = parsed_args["hypergraph"]
     time = parsed_args["time"]
-    qbb_order = parsed_args["qbb_order"]
-    lb = parsed_args["lb"]
     score_function = parsed_args["score_function"]
     verbose = parsed_args["verbose"]
 
@@ -99,8 +97,6 @@ function main(ARGS)
                               decompose=decompose,
                               hypergraph=hypergraph,
                               time=time,
-                              qbb_order=qbb_order,
-                              lb=lb,
                               score_function=score_function)
 end
 

--- a/src/contraction_planning.jl
+++ b/src/contraction_planning.jl
@@ -143,8 +143,9 @@ end
 
 
 """
-    flow_cutter_contraction_plan(tn::TensorNetwork; 
-                                 time::Integer=10,
+    flow_cutter_contraction_plan(tn::TensorNetwork;
+                                 time::Integer=60,
+                                 seed::Integer=-1,
                                  hypergraph::Bool=false)
 
 Use flow cutter to create a contraction plan for 'tn'.
@@ -153,17 +154,20 @@ If flow cutter does not find a tree decomposotion to turn into a contraction pla
 the specified amount of time then the min fill heuristic is used to find a contraction plan.
 
 # Keywords
-- `time::Integer=20`: the number of seconds to run the flow cutter for.
-- `hypergraph::Bool=false`: set if hyperedges in `tn` should be accounted for.
+- `time::Integer=60`: The number of seconds to run the flow cutter for.
+- `seed::Integer=-1`: Sets the seed used by flow cutter. If negative then flow cutter will 
+                      choose a seed.
+- `hypergraph::Bool=false`: Sets if hyperedges in `tn` should be accounted for.
 """
 function flow_cutter_contraction_plan(tn::TensorNetwork; 
-                                      time::Integer=20,
+                                      time::Integer=60,
+                                      seed::Integer=-1,
                                       hypergraph::Bool=false)
     # Convert tn to a line graph and pass it to flow cutter to find an tree decomposition.
     lg, symbol_map = convert_to_line_graph(tn, use_hyperedges=hypergraph)
 
     # Use flow cutter to try find a tree decomposition of the line graph.
-    td = qxg.flow_cutter(lg; time=time)
+    td = qxg.flow_cutter(lg, time; seed=seed)
 
     # If a tree decomposition was found, convert it into a vertex elimination order for lg,
     # otherwise use the min fill heuristic to find an elimination order.

--- a/src/contraction_planning.jl
+++ b/src/contraction_planning.jl
@@ -4,6 +4,7 @@ import QXTns
 
 export convert_to_graph, convert_to_line_graph
 export quickbb_contraction_plan, contraction_scheme
+export flow_cutter_contraction_plan, min_fill_contraction_plan
 export netcon
 
 # **************************************************************************************** #
@@ -67,7 +68,7 @@ convert_to_line_graph(tnc::TensorNetworkCircuit; kwargs...) = convert_to_line_gr
 
 
 # **************************************************************************************** #
-#                                QuickBB contraction
+#                              Contraction Planning
 # **************************************************************************************** #
 
 """
@@ -140,6 +141,107 @@ function quickbb_contraction_plan(tensors::OrderedDict{Symbol, Array{Index, 1}};
     order_to_contraction_plan(order, tensors)
 end
 
+
+"""
+    flow_cutter_contraction_plan(tn::TensorNetwork; 
+                                 time::Integer=10,
+                                 hypergraph::Bool=false)
+
+Use flow cutter to create a contraction plan for 'tn'.
+
+If flow cutter does not find a tree decomposotion to turn into a contraction plan within
+the specified amount of time then the min fill heuristic is used to find a contraction plan.
+
+# Keywords
+- `time::Integer=20`: the number of seconds to run the flow cutter for.
+- `hypergraph::Bool=false`: set if hyperedges in `tn` should be accounted for.
+"""
+function flow_cutter_contraction_plan(tn::TensorNetwork; 
+                                      time::Integer=20,
+                                      hypergraph::Bool=false)
+    # Convert tn to a line graph and pass it to flow cutter to find an tree decomposition.
+    lg, symbol_map = convert_to_line_graph(tn, use_hyperedges=hypergraph)
+
+    # Use flow cutter to try find a tree decomposition of the line graph.
+    td = qxg.flow_cutter(lg; time=time)
+
+    # If a tree decomposition was found, convert it into a vertex elimination order for lg,
+    # otherwise use the min fill heuristic to find an elimination order.
+    if haskey(td, :treewidth)
+        order = Symbol.(qxg.order_from_tree_decomposition(td))
+    else
+        tw, order = qxg.min_fill(lg)
+    end
+
+    # Convert the elimination order to an array of Index structs in tn.
+    order = [symbol_map[lg_vertex] for lg_vertex in order]
+
+    # Convert the elimination order into a contraction plan.
+    order_to_contraction_plan(order, tn)
+end
+
+flow_cutter_contraction_plan(tnc::TensorNetworkCircuit; kwargs...) = flow_cutter_contraction_plan(tnc.tn; kwargs...)
+
+
+"""
+    min_fill_contraction_plan(tn::TensorNetwork;
+                              hypergraph::Bool=false)
+
+Use the min fill heuristic to create a contraction plan for 'tn'.
+
+# Keywords
+- `hypergraph::Bool=false`: set if hyperedges in `tn` should be accounted for.
+"""
+function min_fill_contraction_plan(tn::TensorNetwork;
+                                   hypergraph::Bool=false)
+    # Convert tn to a line graph and pass it to flow cutter to find an tree decomposition.
+    lg, symbol_map = convert_to_line_graph(tn, use_hyperedges=hypergraph)
+
+    # Use flow cutter to try find a tree decomposition of the line graph.
+    tw, order = qxg.min_fill(lg)
+
+    # Convert the elimination order to an array of Index structs in tn.
+    order = [symbol_map[lg_vertex] for lg_vertex in order]
+
+    # Convert the elimination order into a contraction plan.
+    order_to_contraction_plan(order, tn)
+end
+
+min_fill_contraction_plan(tnc::TensorNetworkCircuit; kwargs...) = min_fill_contraction_plan(tnc.tn; kwargs...)
+
+
+"""
+    min_fill_contraction_plan(tensors::OrderedDict{Symbol, Array{Index, 1}})
+
+Use the min fill heuristic to create a contraction plan for the set of tensors described by 
+the OrderedDict `tensors`.
+
+The keys of `tensors` are assumed to be ids/names of tensors and the values are arrays of
+indices belonging to the corrseponding tensor.
+"""
+function min_fill_contraction_plan(tensors::OrderedDict{Symbol, Array{Index, 1}})
+    # Create a graph for the tensors and convert it to to a line graph.
+    tensor_ids = collect(keys(tensors))
+    g = qxg.LabeledGraph(length(tensor_ids))
+    for i = 1:length(tensor_ids)-1
+        for j = i+1:length(tensor_ids)
+            if !isempty(intersect(tensors[tensor_ids[i]], tensors[tensor_ids[j]]))
+                qxg.add_edge!(g, i, j)
+            end
+        end
+    end
+    lg = qxg.line_graph(g)
+
+    # Use the min fill heuristic to find a vertex elimination order for the line graph.
+    tw, order = qxg.min_fill(lg)
+
+    # Convert the elimination order to an array of tensor symbol pairs.
+    order = [parse.(Int, split(String(lg_vertex), '_')) for lg_vertex in order]
+    order = [[tensor_ids[edge[1]], tensor_ids[edge[2]]] for edge in order]
+
+    # Convert the elimination order into a contraction plan.
+    order_to_contraction_plan(order, tensors)
+end
 
 
 # **************************************************************************************** #
@@ -357,7 +459,7 @@ function order_to_contraction_plan(elimination_order::Array{Array{Symbol, 1}, 1}
                 if length(tensors_to_contract) < 37 && any(tensor_sizes .< 2^62)
                     local_contraction_plan = netcon(tn, tensors_to_contract)
                 else
-                    local_contraction_plan = quickbb_contraction_plan(tensors_to_contract)
+                    local_contraction_plan = min_fill_contraction_plan(tensors_to_contract)
                 end
                 append!(plan, local_contraction_plan)
 

--- a/src/contraction_planning.jl
+++ b/src/contraction_planning.jl
@@ -276,6 +276,7 @@ function contraction_scheme(tn::TensorNetwork, num::Integer;
 
     # Use flow cutter to try find a tree decomposition of the line graph.
     td = qxg.flow_cutter(lg, time; seed=seed)
+    flow_cutter_metadata = OrderedDict(1:length(td[:comments]) .=> td[:comments])
 
     # If a tree decomposition was found, convert it into a vertex elimination order for lg,
     # otherwise use the min fill heuristic to find an elimination order.
@@ -292,7 +293,7 @@ function contraction_scheme(tn::TensorNetwork, num::Integer;
     contraction_metadata["Method used"] = method_used
     contraction_metadata["Time allocated"] = time
     contraction_metadata["Seed used"] = seed
-    # contraction_metadata["Returned metadata"] = OrderedDict(flow_cutter_metadata)
+    contraction_metadata["Returned metadata"] = flow_cutter_metadata
     contraction_metadata["Hypergraph used"] = hypergraph
     contraction_metadata["Hyperedge contraction method"] = "Netcon where possible, min fill heuristic otherwise."
 

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -39,7 +39,8 @@ file with the parameters to use during the simulation.
 - `number_bonds_to_slice::Int=2`: the number of edges to slice.
 - `output_prefix::String="simulation_input"`: the prefix to be used for the simulation files.
 - `num_amplitudes::Union{Int64, Nothing}=nothing`: the number of amplitudes to compute.
-- `seed::Union{Int64, Nothing}=nothing`: the seed to be used by flow cutter to find a tree decomposition.
+- `seed::Union{Int64, Nothing}=nothing`: the seed to be used by flow cutter to find a tree 
+                                         decomposition and for randomly selecting amplitudes to compute..
 - `decompose::Bool=true`: set if two qubit gates should be decompoed when the circuit is converted to a tensor network.
 - `kwargs`: all other kwargs are passed to `contraction_scheme` when it is called.
 """

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -39,7 +39,7 @@ file with the parameters to use during the simulation.
 - `number_bonds_to_slice::Int=2`: the number of edges to slice.
 - `output_prefix::String="simulation_input"`: the prefix to be used for the simulation files.
 - `num_amplitudes::Union{Int64, Nothing}=nothing`: the number of amplitudes to compute.
-- `seed::Union{Int64, Nothing}=nothing`: the seed to be used for randomly selecting amplitudes to compute.
+- `seed::Union{Int64, Nothing}=nothing`: the seed to be used by flow cutter to find a tree decomposition.
 - `decompose::Bool=true`: set if two qubit gates should be decompoed when the circuit is converted to a tensor network.
 - `kwargs`: all other kwargs are passed to `contraction_scheme` when it is called.
 """
@@ -55,9 +55,13 @@ function generate_simulation_files(circ::QXZoo.Circuit.Circ;
     @info("Tensor network created with $(length(tnc)) tensors and $(length(bonds(tnc))) bonds")
 
     @info("Get contraction plan and edges to slice using QXGraphDecompositions")
+    fc_seed = (seed === nothing) ? -1 : seed # flow cutter seed expects -1 in place of nothing.
     bonds_to_slice, plan, metadata = contraction_scheme(tnc.tn, number_bonds_to_slice;
+                                                        seed=fc_seed,
                                                         kwargs...)
 
+    # TODO: This part will probably be replaced by a block of code to create variables
+    # for whichever sampling method the user chooses to use. 
     if num_amplitudes === nothing
         amplitudes = amplitudes_all(qubits(tnc))
     else

--- a/test/test_bin.jl
+++ b/test/test_bin.jl
@@ -10,7 +10,7 @@ include("../bin/prepare_rqc_simulation_files.jl")
     # create empty temporary directory
     mktempdir() do path
         prefix = joinpath(path, "rqc_3_3_8")
-        args = ["-p", prefix]
+        args = ["-p", prefix, "--time", "30"]
         Logging.with_logger(Logging.NullLogger()) do # suppress logging
             main(args)
         end
@@ -24,7 +24,7 @@ include("../bin/prepare_rqc_simulation_files.jl")
     mktempdir() do path
         prefix = joinpath(path, "rqc_3_3_8")
         N = 20
-        args = ["-p", prefix, "-a", "$N"]
+        args = ["-p", prefix, "-a", "$N", "--time", "30"]
         Logging.with_logger(Logging.NullLogger()) do # suppress logging
             main(args)
         end

--- a/test/test_contraction_planning.jl
+++ b/test/test_contraction_planning.jl
@@ -64,12 +64,12 @@ end
     tnc = convert_to_tnc(circ, no_input=false, no_output=false, decompose=false)
 
     # Test contraction scheme function
-    edges_to_slice, plan = contraction_scheme(tnc, 3; hypergraph=false)
+    edges_to_slice, plan = contraction_scheme(tnc, 3; time = 30, hypergraph=false)
     @test length(edges_to_slice) == 3 # Should have 3 edges to slice
     @test length(plan) == length(tnc) - 1 - 3 # modified plan should be smaller.
 
     # Test contraction scheme function
-    edges_to_slice, plan = contraction_scheme(tnc, 0)
+    edges_to_slice, plan = contraction_scheme(tnc, 0; time = 30)
     @test length(edges_to_slice) == 0 # Should have 0 edges to slice
     @test length(plan) == length(tnc) - 1
 
@@ -80,7 +80,7 @@ end
     @test length(plan) == 8
 
     # Test contraction scheme function with hypergraph.
-    edges_to_slice, plan = contraction_scheme(tnc, 3; hypergraph=true)
+    edges_to_slice, plan = contraction_scheme(tnc, 3; time = 30, hypergraph=true)
     # Should have 5 indices to slice (1 hyperedge with 2 indices)
     @test length(edges_to_slice) == 5
     @test length(plan) == 3 # modified plan should be smaller.

--- a/test/test_contraction_planning.jl
+++ b/test/test_contraction_planning.jl
@@ -97,6 +97,50 @@ end
     @test length(plan) == 41
 end
 
+@testset "Test flow cutter contraction" begin
+    # A test circuit to test flow cutter on.
+    circ = create_test_circuit()
+    tnc = convert_to_tnc(circ, no_input=false, no_output=true, decompose=false)
+
+    # test contraction plan
+    plan = flow_cutter_contraction_plan(tnc; time=20)
+    @test length(plan) == 5
+
+    # test contracting the network
+    output = contract_tn!(tnc, plan)
+    ref = zeros(8); ref[[1,8]] .= 1/sqrt(2)
+    @test all(output .≈ ref)
+
+    # A test circuit to test flow cutter on.
+    circ = create_test_circuit()
+    tnc = convert_to_tnc(circ, no_input=false, no_output=true, decompose=false)
+
+    # test contraction plan with 0 seconds so the min fill heursitic is used as a fall back
+    # when flow cutter can't find a tree decomposition.
+    plan = flow_cutter_contraction_plan(tnc; time=0)
+    @test length(plan) == 5
+
+    # test contracting the network
+    output = contract_tn!(tnc, plan)
+    ref = zeros(8); ref[[1,8]] .= 1/sqrt(2)
+    @test all(output .≈ ref)
+end
+
+@testset "Test min fill contraction" begin
+    # A test circuit to test the min fill heuristic on.
+    circ = create_test_circuit()
+    tnc = convert_to_tnc(circ, no_input=false, no_output=true, decompose=false)
+
+    # test contraction plan
+    plan = min_fill_contraction_plan(tnc)
+    @test length(plan) == 5
+
+    # test contracting the network
+    output = contract_tn!(tnc, plan)
+    ref = zeros(8); ref[[1,8]] .= 1/sqrt(2)
+    @test all(output .≈ ref)
+end
+
 @testset "Test netcon contraction" begin
     # prepare the circuit.
     circ = create_test_circuit()


### PR DESCRIPTION
### Summary

Functions for using the flow cutter function and min fill heuristic from QXGraphDecompositions were added.

### Rationale

Flow cutter should provide a better alternative to quickbb for finding contraction plans with minimal treewidth.

#### Implementation Details

#### Additional notes

Closes #8 

***Check before merging:***

- [x] All discussions are resolved
- [x] New code is covered by appropriate tests
- [x] Tests are passing locally and on CI
- [x] The documentation is consistent with changes
- [x] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [x] Notebooks/examples not covered by unittests have been tested and updated as required
- [x] The feature branch is up-to-date with the master branch (rebase if behind)
- [x] Incremented the version string in Project.toml file
