### PR TITLE
Update to add compilation pass and update dsl format

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "QXTools"
 uuid = "84f0eee1-10ae-40da-994b-b9d0e53829ae"
 authors = ["QuantEx team"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ will generate the files:
 - `ghz_3.jld`: A data file with tensors
 - `ghz_3.yml`: A parameter file with parameters controlling the simulation
 
-These can be used as input to QXRun to run the simulation on HPC clusters to calculate the amplitudes for 4 bitstrings sampled uniformly.
-For more details and options see the documentation at [docs](doc_url).
+These can be used as input to QXContexts to run the simulation on HPC clusters to calculate the amplitudes for 4 bitstrings sampled uniformly.
+For more details and options see the documentation at [docs](https://juliaqx.github.io/QXContexts.jl/dev/).
 
 # Contributing
 Contributions from users are welcome and we encourage users to open issues and submit merge/pull requests for any problems or feature requests they have. The

--- a/README.md
+++ b/README.md
@@ -1,37 +1,37 @@
-# QXSim
+# QXTools
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaQX.github.io/QXSim.jl/stable)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaQX.github.io/QXSim.jl/dev)
-[![Build Status](https://github.com/JuliaQX/QXSim.jl/workflows/CI/badge.svg)](https://github.com/JuliaQX/QXSim.jl/actions)
-[![Coverage](https://codecov.io/gh/JuliaQX/QXSim.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaQX/QXSim.jl)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaQX.github.io/QXTools.jl/stable)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaQX.github.io/QXTools.jl/dev)
+[![Build Status](https://github.com/JuliaQX/QXTools.jl/workflows/CI/badge.svg)](https://github.com/JuliaQX/QXTools.jl/actions)
+[![Coverage](https://codecov.io/gh/JuliaQX/QXTools.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaQX/QXTools.jl)
 
-QXSim is a Julia package for simulating quantum circuits using tensor networking approaches targeting large distributed memory clusters with hardware
+QXTools is a Julia package for simulating quantum circuits using tensor networking approaches. It targets large distributed memory clusters with hardware
 accelerators. It was developed as part of the QuantEx project, one of the individual software projects of WP8 of PRACE 6IP.
 
-QXSim depends on a number of other Julia packages developed that were also developed as part of the QuantEx project. These include QXZoo which
+QXTools depends on a number of other Julia packages developed that were also developed as part of the QuantEx project. These include QXZoo which
 is capable of generating and manipulating quantum circuits, QXTns which features data structures and functions for manipulating tensor networks,
-QXGraphDecompositions which implements a number of graph algorithms for finding good contraction plans and QXRun which is designed to run on large distributed
+QXGraphDecompositions which implements a number of graph algorithms for finding good contraction plans and QXContexts which is designed to run on large distributed
 clusters.
 
-The design and implementation of QXSim and related packages was inspired by many other frameworks and packages including ITensors, TensorOperations.jl,
+The design and implementation of QXTools and related packages was inspired by many other frameworks and packages including ITensors.jl, TensorOperations.jl,
 Yao.jl, TAL-SH and ExaTN.
 
 # Installation
 
-QXSim is a Julia package and can be installed using Julia's inbuilt package manager from the Julia REPL using.
+QXTools is a Julia package and can be installed using Julia's inbuilt package manager from the Julia REPL using.
 
 ```
 import Pkg
-Pkg.add("QXSim")
+Pkg.add("QXTools")
 ```
 
 # Example usage
 
-An example of how QXSim can be used to calculate a set of amplitudes for small GHZ preparation circuit looks like
+An example of how QXTools can be used to calculate a set of amplitudes for small GHZ preparation circuit looks like
 
 ```
-using QXSim
-using QXSim.Circuits
+using QXTools
+using QXTools.Circuits
 using QXTns
 using QXGraphDecompositions
 
@@ -45,9 +45,9 @@ tnc = convert_to_tnc(circ)
 plan = quickbb_contraction_plan(tnc)
 
 # Contract the network using this plan to find the given amplitude for different outputs
-@show QXSim.single_amplitude(tnc, plan, "000")
-@show QXSim.single_amplitude(tnc, plan, "111")
-@show QXSim.single_amplitude(tnc, plan, "100")
+@show QXTools.single_amplitude(tnc, plan, "000")
+@show QXTools.single_amplitude(tnc, plan, "111")
+@show QXTools.single_amplitude(tnc, plan, "100")
 ```
 
 This is only recommended for small test cases. For larger scale runs one can call the `generate_simulation_files`
@@ -55,8 +55,8 @@ which will do the conversion to a network, find the contraction plan and create 
 calculations. For example
 
 ```
-using QXSim
-using QXSim.Circuits
+using QXTools
+using QXTools.Circuits
 
 # Create ghz circuit
 circ = create_ghz_circuit(3)
@@ -79,7 +79,7 @@ Contributions from users are welcome and we encourage users to open issues and s
 
 # Building documentation
 
-QXSim.jl using [Documenter.jl](https://juliadocs.github.io/Documenter.jl/stable/) to generate documentation. To build
+QXTools.jl using [Documenter.jl](https://juliadocs.github.io/Documenter.jl/stable/) to generate documentation. To build
 the documentation locally run the following from the `docs` folder.
 
 The first time it is will be necessary to instantiate the environment to install dependencies

--- a/bin/prepare_rqc_simulation_files.jl
+++ b/bin/prepare_rqc_simulation_files.jl
@@ -71,7 +71,9 @@ function main(ARGS)
     depth = parsed_args["depth"]
     number_bonds_to_slice = parsed_args["sliced_bonds"]
     num_amplitudes = parsed_args["amplitudes"]
-    if num_amplitudes !== nothing
+    if num_amplitudes === nothing
+        num_amplitudes = 10
+    else
         num_amplitudes = parse(Int64, num_amplitudes)
     end
     output_prefix = parsed_args["prefix"]

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -53,4 +53,4 @@ will generate the files:
 - `ghz_3.jld2`: A data file with tensors
 - `ghz_3.yml`: A parameter file with parameters controlling the simulation
 
-These can be used as input to QXRun to run the simulation on HPC clusters to calculate the amplitudes for 4 bitstrings sampled uniformly.
+These can be used as input to QXContexts to run the simulation on HPC clusters to calculate the amplitudes for 4 bitstrings sampled uniformly.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -13,7 +13,7 @@ The design and implementation of QXTools and related packages was inspired by ma
 ## Where to begin
 
 For getting QXTools installed and setup, see the [Getting Started](@ref) section which has instructions on how to install QXTools and some hello world examples.
-The "Tutorials" section contains some more indepth examples and the "Users Guide" has more details of the design and structure of QXTools.
+The "Tutorials" section contains some more in-depth examples and the "Users Guide" has more details of the design and structure of QXTools.
 
 ```@contents
 Pages = ["users_guide.md"]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,13 +4,9 @@ CurrentModule = QXTools
 
 # QXTools
 
-QXTools is a Julia package for simulating quantum circuits using tensor network approaches and targets large distibuted memory clusters with hardware
-accelerators. It was developed as part of the QuantEx project, one of the individual software projects of WP8 of [PRACE](https://prace-ri.eu/) 6IP.
+QXTools is a Julia package for simulating quantum circuits using tensor network approaches. It targets large distributed memory clusters with hardware accelerators. It was developed as part of the QuantEx project, one of the individual software projects of WP8 of [PRACE](https://prace-ri.eu/) 6IP.
 
-QXTools ties together a number of other Julia packages which are also part of the QuantEx project. These include QXZoo for
-generating and manipulating quantum circuits, QXTns for representing and manipulating tensor networks,
-QXGraphDecompositions which implements a number of graph algorithms for finding good contraction plans and finally QXRun which is designed to run on large distributed
-clusters and carry out the computations using input files generated using QXTools.
+QXTools ties together a number of other Julia packages which are also part of the QuantEx project. These include QXZoo for generating and manipulating quantum circuits, QXTns for representing and manipulating tensor networks, QXGraphDecompositions which implements a number of graph algorithms for finding good contraction plans and finally QXContexts which is designed to run on large distributed clusters and carry out the computations using input files generated using QXTools.
 
 The design and implementation of QXTools and related packages was inspired by many other frameworks and packages including ITensors, TensorOperations.jl, OMEinsum.jl, Yao.jl, TAL-SH and ExaTN.
 

--- a/docs/src/users_guide.md
+++ b/docs/src/users_guide.md
@@ -113,34 +113,26 @@ save t11 output
 ### DSL Format and Instructions
 
 The DSL file is a regular ASCII text file with one instruction per line. Lines beginning with `#` are comments which are
-ignored (except for the first line which contains version information). The first line should have a version string
+ignored (except for the first line which contains version information). The first line has a version string
 which specifies the format version. Comments following the first line contain metadata about the methods used
-to determine the contraction plan used and which edges to slice. Symbols prefixed by a dollar sign indicate variables which are take different values
-for each iteration of the computation. An explanation of each instruction follows
+to determine the contraction plan used and which edges to slice.
 
 #### Outputs
 ```
 outputs 2
 ```
 
-This line indicates that the tensor network has two output tensors. This will create symbols for each of the possible values of
-these output tensors. For a quantum circuit, measurement is performed the computational basis which means that the possible values for the output
-tensors are the vectors `[1, 0]` and `[0, 1]` corresponding to the $| 0 \rangle$ and $| 1 \rangle$ states respectively. For two outputs the following
-symbols and mappings will be defined
-
-```
-o1_0 => [1, 0]
-o1_1 => [0, 1]
-o2_0 => [1, 0]
-o2_1 => [0, 1]
-```
+This line indicates that the tensor network has two output tensors. These tensors are represented in subsequent DSL
+commands by symbols in the format `o{i}` where `{i}` is the index of the given output. To contraction for
+different outputs then involves change that data that these symbols point to prior to the contraction. This is done
+using the `set_output_bonds!` function.
 
 #### Load
 
 Load instructions define a new tensor symbol using data from the input file. Here the first argument is the
 name of the new symbol and the second argument is the key to find the data in the input [Data File](@ref).
-Mulitple tensor symbols can have the same data associated with them. In the following example both `t4` and `t5`
-will have the same data associated with them.
+It is normal that multiple tensor symbols have the same data associated with them, e.g. multiple occurences of the same
+gate. In the following example both `t4` and `t5` both used the data labeled `data_4` in the input [Data File][@ref]
 
 ```
 load t1 data_1
@@ -152,28 +144,33 @@ load t5 data_4
 
 #### View
 
-A view instruction creates a new tensor symbol by taking a view of an existing tensor. The first argument is the new symbol name, the second is the symbol of the tesnor to take the view on, the third argument is the dimension and the final value is the particular value for that dimension. An example view command is as follows
+A view instruction creates a new tensor symbol by taking a view of an existing tensor.
+The first argument is the new symbol name, the second is the symbol of the tensor to take
+the view of, the third argument is the dimension and the final value is the particular value
+for that dimension. An example view command is as follows
 
 ```
-view t13_$v1 t13 3 $v1
+view t13_s t13 3 v1
 ```
 
-The `$v1` variable will be replaced by a particular value before execution as described in the [Parameter File](@ref) section.
-
-#### Delete
-
-The `del` instructions marks a particular tensor for deletion and indicates that it will not be used for the rest of that contraction.
+The `v1` variable will be replaced by a particular value before execution as described in
+the [Parameter File](@ref) section.
 
 #### Contraction
 
-The `ncon` instruction specificies a pairwise contraction of tensors. An example contraction command is as follows
+The `ncon` instruction specifies a pairwise contraction of tensors.
+An example contraction command is as follows
 
 ```
-ncon t15 2,3 $o1 1 t14_$v1_$v2 2,1,3
+ncon t15 2,3 o1 1 t14_s_s 2,1,3
 ```
 
-Which indicates that the `$o1` tensor should be contracted with the `t14_$v1_v2` tensor to get the `t15` tensor. The contraction should be performed over the only rank of the `$o1` tensor and the second rank of the `t14_$v1_$v2` tensor. Einstein summation notation is used for for specifying which indices to contract over. This convention uses repeated indices on the right hand side to indicate that those indices should be contracted over. In the above the `1` index appears twice on the right hand side which indicates that this index should be contracted over.
-For the case where one of the tensors is a scalar, a `0` is used as a placeholder for the indices.
+Which indicates that the `o1` tensor should be contracted with the `t14_s_s` tensor to get the `t15` tensor.
+The contraction should be performed over the only rank of the `o1` tensor and the second rank of the `t14_s_s` tensor.
+Einstein summation notation is used for for specifying which indices to contract over.
+This convention uses repeated indices on the right hand side to indicate that those indices should be contracted over.
+In the above, the `1` index appears twice on the right hand side which indicates that this index should be contracted over.
+For the case where one of the tensors is a scalar, a `0` is used as a placeholder.
 For example if `t1` is a scalar tensor and `t2` is a matrix,
 the multiplication of the matrix by the scalar can be expressed as
 
@@ -186,10 +183,11 @@ is repeated on the right hand side and also appears on the left hand side.
 
 #### Save
 
-The save instruction indicates that the given tensor is an output from the contraction and provides a label for this. The
-value of this tensor will then be used in a reduction operation and/or written to the output file.
+The save instruction indicates that the given tensor is an output from the contraction and provides a label for this.
+The value of this tensor will then be used in a reduction operation and/or written to the output file.
 
 
 ## Data File
 
-The data file is a [JLD](https://github.com/JuliaIO/JLD.jl) file and contains the numerical values of the initial tensors. Each tensor is stored as a multi-dimensional array with a data label that is referenced in `load` commands of the DSL file.
+The data file is a [JLD](https://github.com/JuliaIO/JLD.jl) file and contains the numerical values of the initial tensors.
+Each tensor is stored as a multi-dimensional array with a data label that is referenced in `load` commands of the DSL file.

--- a/docs/src/users_guide.md
+++ b/docs/src/users_guide.md
@@ -1,7 +1,7 @@
 # User's Guide
 
 QXTools generates output files which provide a description of the computations and data
-required to perform the simulation. There are three output files:
+required to perform a simulation. There are three output files:
 
 - Parameter file: This YAML file provides informations on the sliced edges and dimensions as well
 as details of the output amplitudes or sampling method
@@ -72,56 +72,42 @@ instructions work.
 An example of the DSL generated for the contraction of a two qubit GHZ circuit looks like.
 
 ```
-# version: 0.2.0
+# version: 0.3.0
 # Determination of contraction plan :
-#   Method used : quickbb
-#   Time allocated : 120
-#   Ordering used : min_fill
-#   Lower bound flag used : false
+#   Method used : flow cutter
+#   Time allocated : 10
+#   Seed used : -1
 #   Returned metadata :
-#     treewidth : 2
-#     is_optimal : true
-#     time : 0.000147
-#   Hypergraph used : false
+#     1 : c min degree heuristic
+#     2 : c status 3 1618911763948
+#     3 : c min shortcut heuristic
+#     4 : c run with 0.0/0.1/0.2 min balance and node_min_expansion in endless loop with varying seed
+#   Hypergraph used : true
 #   Hyperedge contraction method : Netcon where possible, min fill heuristic otherwise.
 # Slicing :
 #   Method used : greedy treewidth deletion
 #   Edges sliced : 2
 #   Score fucntion used : direct_treewidth
-#   Treewidths after slicing consecutive edges : [1, 1]
+#   Treewidths after slicing consecutive edges : [1, 0]
 outputs 2
 load t1 data_1
 load t2 data_2
 load t3 data_3
 load t4 data_4
 load t5 data_4
-view t2_$v1 t2 3 $v1
-del t2
-view t3_$v1 t3 1 $v1
-del t3
-view t1_$v1 t1 1 $v1
-del t1
-view $o1_$v1 $o1 1 $v1
-del $o1
-ncon I1 2 t3_$v1 2 $o1_$v1 2
-del t3_$v1
-del $o1_$v1
-ncon I2 1 t1_$v1 1,2 t4 2
-del t1_$v1
-del t4
-ncon I3 1,3 t2_$v1 1,2,3 t5 2
-del t2_$v1
-del t5
-ncon I4 2 I3 1,2 $o2 1
-del I3
-del $o2
-ncon t8 2 I1 2 I2 2
-del I1
-del I2
-ncon t9 0 t8 1 I4 1
-del t8
-del I4
-save t9 output
+view o1_s o1 1 v1
+view t3_s t3 1 v1
+view t2_s t2 3 v1
+view t1_s t1 1 v1
+view t5_s t5 1 v2
+view t2_s_s t2_s 2 v2
+ncon I1 2,3 t2_s_s 1,2,3 o2 1
+ncon I2 1 t1_s 1,2 t4 2
+ncon t8 1 o1_s 1 t3_s 1
+ncon t9 1,3 t8 1 t5_s 3
+ncon t10 1 t9 1,3 I1 3,1
+ncon t11 0 t10 1 I2 1
+save t11 output
 ```
 
 ### DSL Format and Instructions

--- a/docs/src/users_guide.md
+++ b/docs/src/users_guide.md
@@ -123,15 +123,14 @@ outputs 2
 ```
 
 This line indicates that the tensor network has two output tensors. These tensors are represented in subsequent DSL
-commands by symbols in the format `o{i}` where `{i}` is the index of the given output. To contraction for
-different outputs then involves change that data that these symbols point to prior to the contraction. This is done
-using the `set_output_bonds!` function.
+commands by symbols in the format `o{i}`, where `{i}` is the index of the given output.
+To contract the tensor network with different values for the output tensors, the data these symbols point to needs to be updated.
 
 #### Load
 
 Load instructions define a new tensor symbol using data from the input file. Here the first argument is the
 name of the new symbol and the second argument is the key to find the data in the input [Data File](@ref).
-It is normal that multiple tensor symbols have the same data associated with them, e.g. multiple occurences of the same
+It is normal that multiple tensor symbols have the same data associated with them, e.g. multiple occurrences of the same
 gate. In the following example both `t4` and `t5` both used the data labeled `data_4` in the input [Data File][@ref]
 
 ```

--- a/src/contraction_planning.jl
+++ b/src/contraction_planning.jl
@@ -331,7 +331,11 @@ function contraction_scheme(tn::TensorNetwork, num::Integer;
         end
         indices_to_slice[i] = indices
     end
-    indices_to_slice = vcat(indices_to_slice...)
+    if length(indices_to_slice) > 0
+        indices_to_slice = vcat(indices_to_slice...)
+    else # in case there are no edges to slice ensure return array has correct type
+        indices_to_slice = Index[]
+    end
 
     metadata = OrderedDict{String, Any}()
     metadata["Determination of contraction plan"] = contraction_metadata

--- a/src/dsl/compute_graph.jl
+++ b/src/dsl/compute_graph.jl
@@ -1,0 +1,180 @@
+using AbstractTrees
+
+# In this file we define a tree data structure which can be used for optimisation passes
+# over contraction commands
+
+"""Generic binary tree node data structure"""
+mutable struct BinaryNode{T}
+    data::T
+    parent::BinaryNode{T}
+    left::BinaryNode{T}
+    right::BinaryNode{T}
+
+    # Root constructor
+    BinaryNode{T}(data) where T = new{T}(data)
+    # Child node constructor
+    BinaryNode{T}(data, parent::BinaryNode{T}) where T = new{T}(data, parent)
+end
+BinaryNode(data) = BinaryNode{typeof(data)}(data)
+
+"""
+    leftchild(data, parent::BinaryNode)
+
+Returns left child node or nothing
+"""
+function leftchild(data, parent::BinaryNode)
+    !isdefined(parent, :left) || error("left child is already assigned")
+    node = typeof(parent)(data, parent)
+    parent.left = node
+end
+
+"""
+    rightchild(data, parent::BinaryNode)
+
+Returns right child node or nothing
+"""
+function rightchild(data, parent::BinaryNode)
+    !isdefined(parent, :right) || error("right child is already assigned")
+    node = typeof(parent)(data, parent)
+    parent.right = node
+end
+
+"""
+    AbstractTrees.children(node::BinaryNode)
+
+Implement children function from AbstractTrees package
+"""
+function AbstractTrees.children(node::BinaryNode)
+    if isdefined(node, :left)
+        if isdefined(node, :right)
+            return (node.left, node.right)
+        end
+        return (node.left,)
+    end
+    isdefined(node, :right) && return (node.right,)
+    return ()
+end
+
+## functions and data structures for trees of contraction commands
+
+"""Structure to represent a contraction command"""
+struct ContractCommand
+    output_name::Symbol
+    output_idxs::Vector{Int}
+    left_name::Symbol
+    left_idxs::Vector{Int}
+    right_name::Symbol
+    right_idxs::Vector{Int}
+end
+
+"""
+    Base.write(io::IO, cmd::ContractCommand)
+
+Function to serialise command to the given IO stream
+"""
+function Base.write(io::IO, cmd::ContractCommand)
+    j = x -> length(x) == 0 ? "0" : join(x, ",")
+    write(io, "ncon $(cmd.output_name) $(j(cmd.output_idxs)) $(cmd.left_name) $(j(cmd.left_idxs)) $(cmd.right_name) $(j(cmd.right_idxs))\n")
+end
+
+"""
+    Base.write(io::IO, tree::tree::BinaryNode{ContractCommand})
+
+Function to serialise tree to the given IO stream
+"""
+function Base.write(io::IO, tree::BinaryNode{ContractCommand})
+    for cmd in PostOrderDFS(tree)
+        write(io, cmd.data)
+    end
+end
+
+"""
+    build_tree(cmds::Vector{ContractCommand})
+
+Function to construct a tree from a list of contraction commands
+"""
+function build_tree(cmds::Vector{ContractCommand})
+    cmd_map = Dict(x.output_name => deepcopy(x) for x in cmds)
+    all_outputs = Set(keys(cmd_map))
+    get_names = x -> [x.left_name, x.right_name]
+    all_inputs = vcat(get_names.(values(cmd_map))...)
+    root_sym = collect(setdiff(all_outputs, all_inputs))[1]
+    root_node = _create_node(cmd_map, root_sym)
+    root_node
+end
+
+function _create_node(cmd_map, cmd_sym)
+    cmd = cmd_map[cmd_sym]
+    node = BinaryNode{ContractCommand}(cmd)
+    if haskey(cmd_map, cmd.left_name)
+        node.left = _create_node(cmd_map, cmd.left_name)
+        node.left.parent = node
+    end
+    if haskey(cmd_map, cmd.right_name)
+        node.right = _create_node(cmd_map, cmd.right_name)
+        node.right.parent = node
+    end
+    node
+end
+
+AbstractTrees.printnode(io::IO, node::BinaryNode{ContractCommand}) = print(io, node.data.output_name)
+
+"""
+    remove_repeated!(indices::Vector{Int64})
+
+Given a list of integers, only keep first occurence of each
+"""
+function remove_repeated!(indices::Vector{Int64})
+    to_remove = Int64[]
+    for i in 1:length(indices)
+        if findfirst(x -> x == indices[i], indices) != i
+            push!(to_remove, i)
+        end
+    end
+    for i in sort(to_remove, rev=true) popat!(indices, i) end
+    indices
+end
+
+function _remove_repeated_in_output!(cmd::ContractCommand, indices::Vector{Int64})
+    # first we create a map of all indices and start with them mapping to themselves
+    all_idx = Set([cmd.output_idxs..., cmd.left_idxs..., cmd.right_idxs...])
+    all_idx_map = Dict(x => x for x in all_idx)
+
+    # go through indices and update index map with first occurence
+    for i in 1:length(indices)
+        first_pos = findfirst(x -> x == indices[i], indices)
+        all_idx_map[cmd.output_idxs[i]] = cmd.output_idxs[first_pos]
+    end
+
+    # replace indices with those they map to in the map
+    replace!(cmd.left_idxs, all_idx_map...)
+    replace!(cmd.right_idxs, all_idx_map...)
+
+    # we can now remove duplicate indices from output_idxs
+    filter!(x -> all_idx_map[x] == x, cmd.output_idxs)
+    nothing
+end
+
+"""
+    remove_repeated!(node::BinaryNode{ContractCommand}, indices=nothing)
+
+Descend contraction tree simplifying contraction commands by removing repeated indices.
+Repeated indices occur where two indices of a tensor are hyper indices of another tensor.
+The process of removing these given a node consists of:
+1. Check if there are repeated indices in lists of left or right indices
+2. If there are then
+"""
+function remove_repeated!(node::BinaryNode{ContractCommand}, indices=nothing)
+    if indices !== nothing
+        _remove_repeated_in_output!(node.data, indices)
+    end
+    is_hyper = x -> length(x) > length(Set(x))
+    if is_hyper(node.data.left_idxs) && isdefined(node, :left)
+        remove_repeated!(node.left, node.data.left_idxs)
+        remove_repeated!(node.data.left_idxs)
+    end
+    if is_hyper(node.data.right_idxs) && isdefined(node, :right)
+        remove_repeated!(node.right, node.data.right_idxs)
+        remove_repeated!(node.data.right_idxs)
+    end
+end

--- a/src/dsl/dsl.jl
+++ b/src/dsl/dsl.jl
@@ -1,11 +1,12 @@
 include("tensor_cache.jl")
+include("compute_graph.jl")
 
 using YAML
 using JLD2
 using Random
 using QXTns
 
-const DSL_VERSION = VersionNumber("0.2")
+const DSL_VERSION = VersionNumber("0.3")
 
 export generate_dsl_files, generate_parameter_file
 
@@ -98,7 +99,7 @@ function generate_dsl_files(tnc::TensorNetworkCircuit,
         # and create a symbol to symbol map to keep track of the mapping
         changed_ids = Dict{Symbol, Symbol}()
         for (i, tensor_sym) in enumerate(output_tensors(tnc_copy))
-            new_sym = Symbol("\$o$i")
+            new_sym = Symbol("o$i")
             replace_tensor_symbol!(tn_copy, tensor_sym, new_sym)
             changed_ids[tensor_sym] = new_sym
         end
@@ -108,22 +109,20 @@ function generate_dsl_files(tnc::TensorNetworkCircuit,
             related_tensors = union([tn_copy[slice_bond] for slice_bond in slice_bond_group]...)
             # slice_tensors = tn_copy[slice_bond]
             for tensor_sym in related_tensors
-                new_sym = Symbol("$(tensor_sym)_\$v$i")
+                new_sym = Symbol("$(tensor_sym)_s")
                 tensor_bonds_in_group = intersect(QXTns.inds(tn_copy[tensor_sym]), slice_bond_group)
-                write_view_command(dsl_io, tn_copy, tensor_sym, new_sym, tensor_bonds_in_group[1], "\$v$(i)")
+                write_view_command(dsl_io, tn_copy, tensor_sym, new_sym, tensor_bonds_in_group[1], "v$(i)")
                 replace_tensor_symbol!(tn_copy, tensor_sym, new_sym)
                 changed_ids[tensor_sym] = new_sym
-                write(dsl_io, "del $tensor_sym\n")
             end
         end
 
         # perform contraction
+        contract_cmds = ContractCommand[]
         for (A_sym, B_sym, C_sym) in plan
             while haskey(changed_ids, A_sym) A_sym = changed_ids[A_sym] end
             while haskey(changed_ids, B_sym) B_sym = changed_ids[B_sym] end
-            write_ncon_command(dsl_io, tn_copy, A_sym, B_sym, C_sym)
-            write(dsl_io, "del $A_sym\n")
-            write(dsl_io, "del $B_sym\n")
+            push!(contract_cmds, gen_ncon_command(tn_copy, A_sym, B_sym, C_sym))
             contract_pair!(tn_copy, A_sym, B_sym, C_sym; mock=true)
         end
 
@@ -135,13 +134,15 @@ function generate_dsl_files(tnc::TensorNetworkCircuit,
             for j in 2:length(tensors)
                 B_sym = tensors[j]
                 C_sym = next_tensor_id!(tn_copy)
-                write_ncon_command(dsl_io, tn_copy, A_sym, B_sym, C_sym)
-                write(dsl_io, "del $A_sym\n")
-                write(dsl_io, "del $B_sym\n")
+                push!(contract_cmds, gen_ncon_command(tn_copy, A_sym, B_sym, C_sym))
                 contract_pair!(tn_copy, A_sym, B_sym, C_sym; mock=true)
                 A_sym = C_sym
             end
         end
+        contraction_tree = build_tree(contract_cmds)
+        remove_repeated!(contraction_tree)
+        write(dsl_io, contraction_tree)
+
         output_tensor = first(keys(tn_copy))
         write(dsl_io, "save $output_tensor output\n")
     end; end
@@ -149,7 +150,7 @@ function generate_dsl_files(tnc::TensorNetworkCircuit,
 end
 
 """
-    write_ncon_command(io::IO, tn::TensorNetwork, A_sym::Symbol, B_sym::Symbol, C_sym::Symbol)
+    gen_ncon_command(tn::TensorNetwork, A_sym::Symbol, B_sym::Symbol, C_sym::Symbol)
 
 Function that constructs and writes command describing pairwise contraction of tensors pointed to
 by symbols A_sym and B_sym to a tensor pointed to by symbol C_sym to the given IO stream in the format
@@ -162,7 +163,7 @@ where the labels are comma separated lists integers which follow the Einstein su
 one of the tensors is rank 0 (a scalar) a '0' is used as a placeholder for the labels to aid parsing.
 
 """
-function write_ncon_command(io::IO, tn::TensorNetwork, A_sym::Symbol, B_sym::Symbol, C_sym::Symbol)
+function gen_ncon_command(tn::TensorNetwork, A_sym::Symbol, B_sym::Symbol, C_sym::Symbol)
     A_indices = copy(QXTns.inds(tn[A_sym]))
     B_indices = copy(QXTns.inds(tn[B_sym]))
     common_indices = intersect(A_indices, B_indices)
@@ -212,8 +213,7 @@ function write_ncon_command(io::IO, tn::TensorNetwork, A_sym::Symbol, B_sym::Sym
 
     update_all_index_map(join_edge_groups(hyperindices(tn[A_sym]), hyperindices(tn[B_sym])))
 
-
-    C_labels = length(C_indices) == 0 ? "0" : join(unique(getindex.([all_index_map], C_indices)), ",")
+    C_labels = length(C_indices) == 0 ? [] : unique(getindex.([all_index_map], C_indices))
 
     # must update A_indices (and B_indices) so only have a single index for each hyper edge group of A (B)
     function update_indices(indices, hyper_index_groups)
@@ -227,10 +227,9 @@ function write_ncon_command(io::IO, tn::TensorNetwork, A_sym::Symbol, B_sym::Sym
         unique(indices)
     end
 
-    A_labels = length(A_indices) == 0 ? "0" : join(getindex.([all_index_map], update_indices(A_indices, hyperindices(tn[A_sym]))), ",")
-    B_labels = length(B_indices) == 0 ? "0" : join(getindex.([all_index_map], update_indices(B_indices, hyperindices(tn[B_sym]))), ",")
-    write(io, "ncon $(C_sym) $(C_labels) $(A_sym) $(A_labels) $(B_sym) $(B_labels)\n")
-    nothing
+    A_labels = length(A_indices) == 0 ? [] : getindex.([all_index_map], update_indices(A_indices, hyperindices(tn[A_sym])))
+    B_labels = length(B_indices) == 0 ? [] : getindex.([all_index_map], update_indices(B_indices, hyperindices(tn[B_sym])))
+    ContractCommand(C_sym, C_labels, A_sym, A_labels, B_sym, B_labels)
 end
 
 """

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -39,7 +39,7 @@ file with the parameters to use during the simulation.
 - `number_bonds_to_slice::Int=2`: the number of edges to slice.
 - `output_prefix::String="simulation_input"`: the prefix to be used for the simulation files.
 - `num_amplitudes::Union{Int64, Nothing}=nothing`: the number of amplitudes to compute.
-- `seed::Union{Int64, Nothing}=nothing`: the seed to be used by flow cutter to find a tree 
+- `seed::Union{Int64, Nothing}=nothing`: the seed to be used by flow cutter to find a tree
                                          decomposition and for randomly selecting amplitudes to compute..
 - `decompose::Bool=true`: set if two qubit gates should be decompoed when the circuit is converted to a tensor network.
 - `kwargs`: all other kwargs are passed to `contraction_scheme` when it is called.
@@ -47,7 +47,7 @@ file with the parameters to use during the simulation.
 function generate_simulation_files(circ::QXZoo.Circuit.Circ;
                                    number_bonds_to_slice::Int=2,
                                    output_prefix::String="simulation_input",
-                                   num_amplitudes::Union{Int64, Nothing}=nothing,
+                                   num_amplitudes::Union{Int64, Nothing}=10,
                                    seed::Union{Int64, Nothing}=nothing,
                                    decompose::Bool=true,
                                    kwargs...)
@@ -62,7 +62,7 @@ function generate_simulation_files(circ::QXZoo.Circuit.Circ;
                                                         kwargs...)
 
     # TODO: This part will probably be replaced by a block of code to create variables
-    # for whichever sampling method the user chooses to use. 
+    # for whichever sampling method the user chooses to use.
     if num_amplitudes === nothing
         amplitudes = amplitudes_all(qubits(tnc))
     else

--- a/test/test_bin.jl
+++ b/test/test_bin.jl
@@ -10,14 +10,14 @@ include("../bin/prepare_rqc_simulation_files.jl")
     # create empty temporary directory
     mktempdir() do path
         prefix = joinpath(path, "rqc_3_3_8")
-        args = ["-p", prefix, "--time", "30"]
+        args = ["-p", prefix, "--time", "30", "-a", "15"]
         Logging.with_logger(Logging.NullLogger()) do # suppress logging
             main(args)
         end
         @test all([isfile(prefix * suffix) for suffix in [".qx", ".jld2", ".yml"]])
 
         params = YAML.load_file(prefix * ".yml")
-        @test length(params["amplitudes"]) == 2^9
+        @test length(params["amplitudes"]) == 15
     end
 
     # create empty temporary directory

--- a/test/test_dsl.jl
+++ b/test/test_dsl.jl
@@ -60,7 +60,7 @@ end
     b_hyper_indices = [[1, 2]]
     t1 = push!(tn, QXTensor(as, a_hyper_indices))
     t2 = push!(tn, QXTensor(bs, b_hyper_indices))
-    QXTools.write_ncon_command(io, tn, t1, t2, :t3)
+    write(io, QXTools.gen_ncon_command(tn, t1, t2, :t3))
     cmd = String(take!(io))
     @test cmd == "ncon t3 1,2 t1 1,2 t2 2\n"
 
@@ -72,7 +72,7 @@ end
     b_hyper_indices = Array{Int64,1}[]
     t1 = push!(tn, QXTensor(as, a_hyper_indices))
     t2 = push!(tn, QXTensor(bs, b_hyper_indices))
-    QXTools.write_ncon_command(io, tn, t1, t2, :t3)
+    write(io, QXTools.gen_ncon_command(tn, t1, t2, :t3))
     cmd = String(take!(io))
     @test cmd == "ncon t3 0 t1 1 t2 1,1\n"
 
@@ -91,7 +91,7 @@ end
     push!(tn, QXTensor(b_i, b_hyper))
 
     io = IOBuffer()
-    QXTools.write_ncon_command(io, tn, :t1, :t2, :t3)
+    write(io, QXTools.gen_ncon_command(tn, :t1, :t2, :t3))
     @test String(take!(io)) == "ncon t3 1,3,5,2,9,10 t1 1,2,3,5,2,9 t2 2,10\n"
 end
 

--- a/test/test_dsl.jl
+++ b/test/test_dsl.jl
@@ -109,3 +109,9 @@ end
     @test cmd == "view t1v1 t1 2 v1\n"
 end
 
+@testset "Test compute graph" begin
+
+
+
+end
+

--- a/test/test_dsl.jl
+++ b/test/test_dsl.jl
@@ -108,10 +108,3 @@ end
     cmd = String(take!(io))
     @test cmd == "view t1v1 t1 2 v1\n"
 end
-
-@testset "Test compute graph" begin
-
-
-
-end
-


### PR DESCRIPTION
### Summary

Add compilation pass and update dsl format. Closes #11 #14

### Rationale

When the list of dsl commands is first compiled there are many operations which have groups of hyperindices which appear in larger contractions but not the smaller ones. To get rid of these requires constructing a compute graph and working from the root back down the tree updating each operation.

#### Implementation Details

- Add binary tree data structure to represent compute graph and update function to iterate over this
- Update DSL format to remove delete commands and simplify variables

#### Additional notes

Update DSL format to 0.3.0

<hr>

***Check before merging:***

- [x] All discussions are resolved
- [x] New code is covered by appropriate tests
- [x] Tests are passing locally and on CI
- [x] The documentation is consistent with changes
- [x] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [x] Notebooks/examples not covered by unittests have been tested and updated as required
- [x] The feature branch is up-to-date with the master branch (rebase if behind)
- [x] Incremented the version string in Project.toml file
