### PR TITLE
7 update generated yaml file

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QXTools"
 uuid = "84f0eee1-10ae-40da-994b-b9d0e53829ae"
 authors = ["QuantEx team"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -12,6 +12,7 @@ JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Metis = "2679e427-3c69-5b7f-982b-ece356f1e94b"
 QXGraphDecompositions = "b15f1ded-d19a-4aca-a940-1991fcfc7750"
 QXTns = "995e1dad-72e3-4b97-b122-7deaeb8b44f9"
 QXZoo = "f27fdc93-0c88-4b5a-91cb-e8275adac0f6"

--- a/bin/prepare_rqc_simulation_files.jl
+++ b/bin/prepare_rqc_simulation_files.jl
@@ -42,7 +42,7 @@ function parse_commandline(ARGS)
             default = :direct_treewidth
             arg_type = Symbol
         "--output_method"
-            help = "Method for selecting amplitudes to output. (:uniform, :rejection, :list)"
+            help = "Method for selecting amplitudes to output. (uniform, rejection, list)"
             default = :list
             arg_type = Symbol
         "--num_outputs", "-n"

--- a/bin/prepare_rqc_simulation_files.jl
+++ b/bin/prepare_rqc_simulation_files.jl
@@ -45,8 +45,8 @@ function parse_commandline(ARGS)
             help = "Method for selecting amplitudes to output. (:uniform, :rejection, :list)"
             default = :list
             arg_type = Symbol
-        "--amplitudes", "-a"
-            help = "Number of amplitudes to output"
+        "--num_outputs", "-n"
+            help = "Number of amplitudes or bitstring samples to output"
             default = nothing
         "--M"
             help = "Constant to use for rejection sampling"
@@ -56,6 +56,9 @@ function parse_commandline(ARGS)
             help = "Fix rejection sampling constant for frugal sampling"
             default = false
             arg_type = Bool
+        "--bitstrings"
+            help = "The bitstrings to compute amplitudes for if list output method is selected"
+            default = nothing
         "--prefix", "-p"
             help = "Prefix to use for output files"
             required = true
@@ -86,15 +89,11 @@ function main(ARGS)
 
     # Output parameters.
     output_method = parsed_args["output_method"]
-    num_amplitudes = parsed_args["amplitudes"]
-    if num_amplitudes === nothing
-        num_amplitudes = 10
-    else
-        num_amplitudes = parse(Int64, num_amplitudes)
-    end
+    num_outputs = parsed_args["num_outputs"]
+    num_outputs === nothing || (num_outputs = parse(Int64, num_outputs))
     M = parsed_args["M"]
     fix_M = parsed_args["fix_M"]
-
+    bitstrings = parsed_args["bitstrings"]
 
     # Other parameters.
     seed = parsed_args["seed"]
@@ -110,16 +109,17 @@ function main(ARGS)
 
     generate_simulation_files(circ;
                               number_bonds_to_slice=number_bonds_to_slice,
+                              decompose=decompose,
                               output_prefix=output_prefix,
                               output_method=output_method,
-                              num_amplitudes=num_amplitudes,
+                              num_outputs=num_outputs,
                               seed=seed,
-                              decompose=decompose,
                               hypergraph=hypergraph,
                               time=time,
                               score_function=score_function,
                               M=M,
-                              fix_M=fix_M)
+                              fix_M=fix_M,
+                              bitstrings=bitstrings)
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__

--- a/bin/prepare_rqc_simulation_files.jl
+++ b/bin/prepare_rqc_simulation_files.jl
@@ -42,8 +42,8 @@ function parse_commandline(ARGS)
             default = :direct_treewidth
             arg_type = Symbol
         "--output_method"
-            help = "Method for selecting amplitudes to output. (:uniform or :rejection)"
-            default = :uniform
+            help = "Method for selecting amplitudes to output. (:uniform, :rejection, :list)"
+            default = :list
             arg_type = Symbol
         "--amplitudes", "-a"
             help = "Number of amplitudes to output"

--- a/bin/prepare_rqc_simulation_files.jl
+++ b/bin/prepare_rqc_simulation_files.jl
@@ -18,13 +18,6 @@ function parse_commandline(ARGS)
             help = "Number layers"
             default = 8
             arg_type = Int64
-        "--sliced_bonds", "-s"
-            help = "Number bonds to slice"
-            default = 2
-            arg_type = Int64
-        "--amplitudes", "-a"
-            help = "Number of amplitudes"
-            default = nothing
         "--seed"
             help = "Seed to use for circuit generation, contraction planning and selecting amplitudes to compute."
             default = nothing
@@ -37,21 +30,32 @@ function parse_commandline(ARGS)
             default = true
             arg_type = Bool
         "--time"
-            help = "The number of seconds to run quickbb for."
-            default = 120
+            help = "The number of seconds to run flow cutter for."
+            default = 30
             arg_type = Int64
-        "--qbb_order"
-            help = "The branching order to be used by quickbb."
-            default = :min_fill
-            arg_type = Symbol
-        "--lb"
-            help = "Set if a lowerbound for the treewidth should be computed."
-            default = false
-            arg_type = Bool
+        "--sliced_bonds", "-s"
+            help = "Number bonds to slice"
+            default = 2
+            arg_type = Int64
         "--score_function"
             help = "Function to maximise when selecting vertices to remove."
             default = :direct_treewidth
             arg_type = Symbol
+        "--output_method"
+            help = "Method for selecting amplitudes to output. (:uniform or :rejection)"
+            default = :uniform
+            arg_type = Symbol
+        "--amplitudes", "-a"
+            help = "Number of amplitudes to output"
+            default = nothing
+        "--M"
+            help = "Constant to use for rejection sampling"
+            default = 0.001
+            arg_type = Float64
+        "--fix_M"
+            help = "Fix rejection sampling constant for frugal sampling"
+            default = false
+            arg_type = Bool
         "--prefix", "-p"
             help = "Prefix to use for output files"
             required = true
@@ -66,25 +70,38 @@ end
 function main(ARGS)
     parsed_args = parse_commandline(ARGS)
 
+    # Citcuit parameters.
     rows = parsed_args["rows"]
     cols = parsed_args["cols"]
     depth = parsed_args["depth"]
+
+    # Tensor network parameters.
+    decompose = parsed_args["decompose"]
+    hypergraph = parsed_args["hypergraph"]
+
+    # Contraction and slicing parameters.
+    time = parsed_args["time"]
+    score_function = parsed_args["score_function"]
     number_bonds_to_slice = parsed_args["sliced_bonds"]
+
+    # Output parameters.
+    output_method = parsed_args["output_method"]
     num_amplitudes = parsed_args["amplitudes"]
     if num_amplitudes === nothing
         num_amplitudes = 10
     else
         num_amplitudes = parse(Int64, num_amplitudes)
     end
-    output_prefix = parsed_args["prefix"]
+    M = parsed_args["M"]
+    fix_M = parsed_args["fix_M"]
+
+
+    # Other parameters.
     seed = parsed_args["seed"]
     if seed !== nothing
         seed = parse(Int64, seed)
     end
-    decompose = parsed_args["decompose"]
-    hypergraph = parsed_args["hypergraph"]
-    time = parsed_args["time"]
-    score_function = parsed_args["score_function"]
+    output_prefix = parsed_args["prefix"]
     verbose = parsed_args["verbose"]
 
     @info("Create circuit with $(rows * cols) qubits")
@@ -94,12 +111,15 @@ function main(ARGS)
     generate_simulation_files(circ;
                               number_bonds_to_slice=number_bonds_to_slice,
                               output_prefix=output_prefix,
+                              output_method=output_method,
                               num_amplitudes=num_amplitudes,
                               seed=seed,
                               decompose=decompose,
                               hypergraph=hypergraph,
                               time=time,
-                              score_function=score_function)
+                              score_function=score_function,
+                              M=M,
+                              fix_M=fix_M)
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -26,7 +26,7 @@ circ = create_ghz_circuit(3)
 tnc = convert_to_tnc(circ)
 
 # Find a good contraction plan
-plan = quickbb_contraction_plan(tnc)
+plan = flow_cutter_contraction_plan(tnc; time=10)
 
 # Contract the network using this plan to find the given amplitude for different outputs
 @show QXTools.single_amplitude(tnc, plan, "000")
@@ -45,7 +45,11 @@ using QXTools.Circuits
 # Create ghz circuit
 circ = create_ghz_circuit(3)
 
-generate_simulation_files(circ, 2, "ghz_3", 4)
+generate_simulation_files(circ; 
+                          number_bonds_to_slice=2, 
+                          output_prefix="ghz_3",
+                          output_method=:uniform
+                          num_outputs=4)
 ```
 
 will generate the files:

--- a/docs/src/users_guide.md
+++ b/docs/src/users_guide.md
@@ -75,11 +75,12 @@ An example of the DSL generated for the contraction of a two qubit GHZ circuit l
 # version: 0.3.0
 # Determination of contraction plan :
 #   Method used : flow cutter
-#   Time allocated : 10
+#   Treewidth : 2
+#   Time allocated : 30
 #   Seed used : -1
 #   Returned metadata :
 #     1 : c min degree heuristic
-#     2 : c status 3 1618911763948
+#     2 : c status 3 1620299104065
 #     3 : c min shortcut heuristic
 #     4 : c run with 0.0/0.1/0.2 min balance and node_min_expansion in endless loop with varying seed
 #   Hypergraph used : true
@@ -95,17 +96,17 @@ load t2 data_2
 load t3 data_3
 load t4 data_4
 load t5 data_4
-view o1_s o1 1 v1
-view t3_s t3 1 v1
 view t2_s t2 3 v1
+view t3_s t3 1 v1
 view t1_s t1 1 v1
+view o1_s o1 1 v1
 view t5_s t5 1 v2
 view t2_s_s t2_s 2 v2
-ncon I1 2,3 t2_s_s 1,2,3 o2 1
-ncon I2 1 t1_s 1,2 t4 2
-ncon t8 1 o1_s 1 t3_s 1
+ncon t8 2 t3_s 2 o1_s 2
 ncon t9 1,3 t8 1 t5_s 3
+ncon I1 2,3 t2_s_s 1,2,3 o2 1
 ncon t10 1 t9 1,3 I1 3,1
+ncon I2 1 t1_s 1,2 t4 2
 ncon t11 0 t10 1 I2 1
 save t11 output
 ```

--- a/src/contraction_planning.jl
+++ b/src/contraction_planning.jl
@@ -282,6 +282,7 @@ function contraction_scheme(tn::TensorNetwork, num::Integer;
     # otherwise use the min fill heuristic to find an elimination order.
     if haskey(td, :treewidth)
         order = Symbol.(qxg.order_from_tree_decomposition(td))
+        tw = td[:treewidth]
         method_used = "flow cutter"
     else
         tw, order = qxg.min_fill(lg)
@@ -291,6 +292,7 @@ function contraction_scheme(tn::TensorNetwork, num::Integer;
     # Create a dictionary for metadata regarding the contraction plan.
     contraction_metadata = OrderedDict{String, Any}()
     contraction_metadata["Method used"] = method_used
+    contraction_metadata["Treewidth"] = tw
     contraction_metadata["Time allocated"] = time
     contraction_metadata["Seed used"] = seed
     contraction_metadata["Returned metadata"] = flow_cutter_metadata

--- a/src/dsl/dsl.jl
+++ b/src/dsl/dsl.jl
@@ -261,22 +261,37 @@ function write_view_command(dsl_io::IO, tn::TensorNetwork, tensor_sym::Symbol, n
 end
 
 """
-    generate_parameter_file(filename::String
+    generate_parameter_file(filename::String,
                             sliced_bond_groups::Array{<:Array{<:Index, 1}, 1},
                             amplitudes::Union{Base.Generator, <: AbstractArray})
 
 Generate a yml file with parameters corresponding to partitions and dimensions of each
 along with the amplitudes to contract for.
+
+output:
+    fix_M: false
+    M: 0.001
+    num_samples: 10
+    output_method: rejection
+    seed: ~
+partitions:
+    parameters:
+        v1: 2
+        v2: 2
 """
 function generate_parameter_file(filename_prefix::String,
-                                 sliced_bond_groups::Array{<:Array{<:Index, 1}, 1},
-                                 amplitudes::Union{Base.Generator, <: AbstractArray})
+                                 sliced_bond_groups::Array{<:Array{<:Index, 1}, 1};
+                                 output_parameters...)
+    
     partition_dims = OrderedDict{String, Int64}()
     for (i, sliced_bond_group) in enumerate(sliced_bond_groups)
         partition_dims["v$i"] = QXTns.dim(sliced_bond_group[1])
     end
     partition_parameters = Dict("parameters" => partition_dims)
-    config = Dict("partitions" => partition_parameters,
-                         "amplitudes" => collect(amplitudes))
+
+    config = Dict()
+    config["partitions"] = partition_parameters
+    config["output"] = output_parameters
+
     YAML.write_file("$(filename_prefix).yml", config)
 end

--- a/src/dsl/dsl.jl
+++ b/src/dsl/dsl.jl
@@ -280,8 +280,8 @@ partitions:
         v2: 2
 """
 function generate_parameter_file(filename_prefix::String,
-                                 sliced_bond_groups::Array{<:Array{<:Index, 1}, 1};
-                                 output_parameters...)
+                                 sliced_bond_groups::Array{<:Array{<:Index, 1}, 1},
+                                 output_parameters)
     
     partition_dims = OrderedDict{String, Int64}()
     for (i, sliced_bond_group) in enumerate(sliced_bond_groups)
@@ -290,8 +290,8 @@ function generate_parameter_file(filename_prefix::String,
     partition_parameters = Dict("parameters" => partition_dims)
 
     config = Dict()
-    config["partitions"] = partition_parameters
     config["output"] = output_parameters
+    config["partitions"] = partition_parameters
 
     YAML.write_file("$(filename_prefix).yml", config)
 end

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -46,7 +46,7 @@ file with the parameters to use during the simulation.
 """
 function generate_simulation_files(circ::QXZoo.Circuit.Circ;
                                    number_bonds_to_slice::Int=2,
-                                   output_method::Symbol=:uniform,
+                                   output_method::Symbol=:list,
                                    output_prefix::String="simulation_input",
 <<<<<<< HEAD
                                    num_amplitudes::Union{Int64, Nothing}=10,
@@ -83,12 +83,13 @@ function generate_simulation_files(circ::QXZoo.Circuit.Circ;
     output_args = Dict()
     output_args[:output_method] = output_method
     if output_method == :rejection
+        output_args[:num_qubits] = tnc.qubits
         output_args[:M] = M
         output_args[:fix_M] = fix_M
         output_args[:seed] = seed
         output_args[:num_samples] = num_amplitudes === nothing ? 10 : num_amplitudes
 
-    elseif output_method == :uniform
+    elseif output_method == :list
         if num_amplitudes === nothing
             amplitudes = amplitudes_all(qubits(tnc))
         else

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -70,13 +70,14 @@ function generate_simulation_files(circ::QXZoo.Circuit.Circ;
 
     @info("Write parameter file for retrieving $num_outputs amplitudes")
     output_args = OrderedDict()
-    output_args[:output_method] = output_method
+    output_args[:method] = output_method
+    output_params = OrderedDict()
     if output_method == :rejection
-        output_args[:num_qubits] = tnc.qubits
-        output_args[:M] = M
-        output_args[:fix_M] = fix_M
-        output_args[:seed] = seed
-        output_args[:num_samples] = num_outputs === nothing ? 10 : num_outputs
+        output_params[:num_qubits] = tnc.qubits
+        output_params[:M] = M
+        output_params[:fix_M] = fix_M
+        output_params[:seed] = seed
+        output_params[:num_samples] = num_outputs === nothing ? 10 : num_outputs
 
     elseif output_method == :list
         if bitstrings === nothing
@@ -85,15 +86,16 @@ function generate_simulation_files(circ::QXZoo.Circuit.Circ;
         if num_outputs === nothing
             num_outputs = length(bitstrings)
         end
-        output_args[:num_samples] = num_outputs
-        output_args[:bitstrings] = collect(bitstrings)[1:num_outputs]
+        output_params[:num_samples] = num_outputs
+        output_params[:bitstrings] = collect(bitstrings)[1:num_outputs]
 
     elseif output_method == :uniform
-        output_args[:num_qubits] = tnc.qubits
-        output_args[:num_samples] = num_outputs === nothing ? 10 : num_outputs
-        output_args[:seed] = seed
+        output_params[:num_qubits] = tnc.qubits
+        output_params[:num_samples] = num_outputs === nothing ? 10 : num_outputs
+        output_params[:seed] = seed
     end
-    generate_parameter_file(output_prefix, bond_groups_to_slice; output_args...)
+    output_args[:params] = output_params
+    generate_parameter_file(output_prefix, bond_groups_to_slice, output_args)
 
     @info("Prepare DSL and data files")
     generate_dsl_files(tnc, output_prefix, plan, bond_groups_to_slice; force=true, metadata=metadata)

--- a/test/test_bin.jl
+++ b/test/test_bin.jl
@@ -10,22 +10,21 @@ include("../bin/prepare_rqc_simulation_files.jl")
     # create empty temporary directory
     mktempdir() do path
         prefix = joinpath(path, "rqc_3_3_8")
-        args = ["-p", prefix, "--time", "30", "-a", "15"]
+        args = ["-p", prefix, "--time", "30", "-n", "15"]
         Logging.with_logger(Logging.NullLogger()) do # suppress logging
             main(args)
         end
         @test all([isfile(prefix * suffix) for suffix in [".qx", ".jld2", ".yml"]])
 
         params = YAML.load_file(prefix * ".yml")
-        @test length(params["amplitudes"]) == 15
-        @test length(params["output"]["bitstrings"]) == 2^9
+        @test length(params["output"]["bitstrings"]) == 15
     end
 
     # create empty temporary directory
     mktempdir() do path
         prefix = joinpath(path, "rqc_3_3_8")
         N = 20
-        args = ["-p", prefix, "-a", "$N", "--time", "30", "--output_method", "rejection"]
+        args = ["-p", prefix, "-n", "$N", "--time", "30", "--output_method", "rejection"]
         Logging.with_logger(Logging.NullLogger()) do # suppress logging
             main(args)
         end
@@ -40,7 +39,7 @@ include("../bin/prepare_rqc_simulation_files.jl")
     mktempdir() do path
         prefix = joinpath(path, "rqc_3_3_8")
         N = 20
-        args = ["-p", prefix, "-a", "$N", "--time", "30"]
+        args = ["-p", prefix, "-n", "$N", "--time", "30"]
         Logging.with_logger(Logging.NullLogger()) do # suppress logging
             main(args)
         end

--- a/test/test_bin.jl
+++ b/test/test_bin.jl
@@ -18,6 +18,22 @@ include("../bin/prepare_rqc_simulation_files.jl")
 
         params = YAML.load_file(prefix * ".yml")
         @test length(params["amplitudes"]) == 15
+        @test length(params["output"]["bitstrings"]) == 2^9
+    end
+
+    # create empty temporary directory
+    mktempdir() do path
+        prefix = joinpath(path, "rqc_3_3_8")
+        N = 20
+        args = ["-p", prefix, "-a", "$N", "--time", "30", "--output_method", "rejection"]
+        Logging.with_logger(Logging.NullLogger()) do # suppress logging
+            main(args)
+        end
+        @test all([isfile(prefix * suffix) for suffix in [".qx", ".jld2", ".yml"]])
+
+        params = YAML.load_file(prefix * ".yml")
+        @test params["output"]["output_method"] == "rejection"
+        @test params["output"]["num_samples"] == N
     end
 
     # create empty temporary directory
@@ -31,7 +47,7 @@ include("../bin/prepare_rqc_simulation_files.jl")
         @test all([isfile(prefix * suffix) for suffix in [".qx", ".jld2", ".yml"]])
 
         params = YAML.load_file(prefix * ".yml")
-        @test length(params["amplitudes"]) <= N
+        @test length(params["output"]["bitstrings"]) <= N
     end
 end
 end

--- a/test/test_bin.jl
+++ b/test/test_bin.jl
@@ -17,7 +17,7 @@ include("../bin/prepare_rqc_simulation_files.jl")
         @test all([isfile(prefix * suffix) for suffix in [".qx", ".jld2", ".yml"]])
 
         params = YAML.load_file(prefix * ".yml")
-        @test length(params["output"]["bitstrings"]) == 15
+        @test length(params["output"]["params"]["bitstrings"]) == 15
     end
 
     # create empty temporary directory
@@ -31,8 +31,8 @@ include("../bin/prepare_rqc_simulation_files.jl")
         @test all([isfile(prefix * suffix) for suffix in [".qx", ".jld2", ".yml"]])
 
         params = YAML.load_file(prefix * ".yml")
-        @test params["output"]["output_method"] == "rejection"
-        @test params["output"]["num_samples"] == N
+        @test params["output"]["method"] == "rejection"
+        @test params["output"]["params"]["num_samples"] == N
     end
 
     # create empty temporary directory
@@ -46,7 +46,7 @@ include("../bin/prepare_rqc_simulation_files.jl")
         @test all([isfile(prefix * suffix) for suffix in [".qx", ".jld2", ".yml"]])
 
         params = YAML.load_file(prefix * ".yml")
-        @test length(params["output"]["bitstrings"]) <= N
+        @test length(params["output"]["params"]["bitstrings"]) <= N
     end
 end
 end

--- a/test/test_contraction_planning.jl
+++ b/test/test_contraction_planning.jl
@@ -64,12 +64,12 @@ end
     tnc = convert_to_tnc(circ, no_input=false, no_output=false, decompose=false)
 
     # Test contraction scheme function
-    edges_to_slice, plan = contraction_scheme(tnc, 3; time = 30, hypergraph=false)
+    edges_to_slice, plan = contraction_scheme(tnc, 3; time = 15, hypergraph=false)
     @test length(edges_to_slice) == 3 # Should have 3 edges to slice
     @test length(plan) == length(tnc) - 1 - 3 # modified plan should be smaller.
 
     # Test contraction scheme function
-    edges_to_slice, plan = contraction_scheme(tnc, 0; time = 30)
+    edges_to_slice, plan = contraction_scheme(tnc, 0; time = 15)
     @test length(edges_to_slice) == 0 # Should have 0 edges to slice
     @test length(plan) == length(tnc) - 1
 
@@ -80,7 +80,7 @@ end
     @test length(plan) == 8
 
     # Test contraction scheme function with hypergraph.
-    edges_to_slice, plan = contraction_scheme(tnc, 3; time = 30, hypergraph=true)
+    edges_to_slice, plan = contraction_scheme(tnc, 3; time = 15, hypergraph=true)
     # Should have 5 indices to slice (1 hyperedge with 2 indices)
     @test length(edges_to_slice) == 5
     @test length(plan) == 3 # modified plan should be smaller.
@@ -103,7 +103,7 @@ end
     tnc = convert_to_tnc(circ, no_input=false, no_output=true, decompose=false)
 
     # test contraction plan
-    plan = flow_cutter_contraction_plan(tnc; time=20)
+    plan = flow_cutter_contraction_plan(tnc; time=15)
     @test length(plan) == 5
 
     # test contracting the network


### PR DESCRIPTION
### Summary

Adds output method and parameters to generated yaml file for rejection and uniform sampling. Closes #7 
Arguments for scripts and functions used to generate simulation files updated accordingly to expose output options to the user.
Returns treewidth of contraction plan used to the metadata in the header of generated dsl files.

### Rationale

Allows the user to select the output method to be used when simulating a circuit according to the generated simulation files.

#### Implementation Details

#### Additional notes

<hr>

***Check before merging:***

- [x] All discussions are resolved
- [x] New code is covered by appropriate tests
- [x] Tests are passing locally and on CI
- [x] The documentation is consistent with changes
- [x] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [x] Notebooks/examples not covered by unittests have been tested and updated as required
- [x] The feature branch is up-to-date with the master branch (rebase if behind)
- [x] Incremented the version string in Project.toml file
