### PR TITLE
Fix incorrect load dimensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QXTools"
 uuid = "84f0eee1-10ae-40da-994b-b9d0e53829ae"
 authors = ["QuantEx team"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/compute_graph/compute_graph.jl
+++ b/src/compute_graph/compute_graph.jl
@@ -24,7 +24,7 @@ function build_compute_graph(tnc::TensorNetworkCircuit,
     # add a load node for each tensor
     for t in keys(tnc)
         data_symbol = push!(tc, tensor_data(tnc, t))
-        op = LoadCommand(t, data_symbol, collect(size(tnc[t])))
+        op = LoadCommand(t, data_symbol, collect(size(tensor_data(tnc, t))))
         nodes[t] = ComputeNode{LoadCommand}(op)
     end
 

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -3,7 +3,7 @@ using YAML
 
 export amplitudes_uniform, amplitudes_all
 export generate_simulation_files, run_simulation
-export generate_parameter_file
+export generate_parameter_file, generate_dsl_files
 
 """
     amplitudes_all(qubits::Int)


### PR DESCRIPTION
### Summary

Fix issue by getting the size of tensor returned by `tensor_data` method

### Rationale

Incorrect dimension in LoadCommand will lead to issues when working with compute graph

<hr>

***Check before merging:***

- [x] All discussions are resolved
- [x] New code is covered by appropriate tests
- [x] Tests are passing locally and on CI
- [x] The documentation is consistent with changes
- [x] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [x] Notebooks/examples not covered by unittests have been tested and updated as required
- [x] The feature branch is up-to-date with the master branch (rebase if behind)
- [x] Incremented the version string in Project.toml file
