### PR TITLE
Add additional tutorials on constructing circuits and distributed simulation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
 TestSetExtensions = "98d24dd4-01ad-11ea-1b02-c9a08f80db04"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
@@ -36,6 +37,7 @@ QXZoo = "0.1"
 Reexport = "1.1"
 TensorOperations = "3.1"
 TestSetExtensions = "2.0"
+TimerOutputs = "0.5"
 YAML = "0.4"
 julia = "1.6"
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For more details and options see the documentation at [docs](https://juliaqx.git
 
 ## Contributing
 Contributions from users are welcome and we encourage users to open issues and submit merge/pull requests for any problems or feature requests they have. The
-[CONTRIBUTING.md](CONTRIBUTION.md) has further details of the contribution guidelines.
+[CONTRIBUTING.md](CONTRIBUTING.md) has further details of the contribution guidelines.
 
 
 ## Building documentation

--- a/bin/qxrun.jl
+++ b/bin/qxrun.jl
@@ -1,0 +1,102 @@
+# using MPI
+using QXContexts
+using ArgParse
+using TimerOutputs
+using LinearAlgebra
+
+"""
+    parse_commandline(ARGS)
+
+Parse command line arguments and return argument dictionary
+"""
+function parse_commandline(ARGS)
+    s = ArgParseSettings("QXContexts")
+
+    @add_arg_table! s begin
+        "--dsl", "-d"
+            help = "DSL file path"
+            required = true
+            arg_type = String
+        "--parameter-file", "-p"
+            help = "Parameter file path, default is to use dsl filename with .yml suffix"
+            default = nothing
+            arg_type = String
+        "--input-file", "-i"
+            help = "Input data file path, default is to use dsl filename with .jld2 suffix"
+            default = nothing
+            arg_type = String
+        "--output-file", "-o"
+            help = "Output data file path"
+            required = true
+            arg_type = String
+        "--number-amplitudes", "-a"
+            help = "Number of amplitudes to calculate out of number in parameter file"
+            default = nothing
+            arg_type = Int
+        "--number-slices", "-n"
+            help = "The number of slices to use out of number given in parameter file"
+            default = nothing
+            arg_type = Int
+        "--sub-comm-size", "-s"
+            help = "The number of ranks to assign to each sub-communicator for partitions"
+            default = 1
+            arg_type = Int
+        "--mpi", "-m"
+            help = "Use MPI"
+            action = :store_true
+        "--gpu", "-g"
+            help = "Use GPU if available"
+            action = :store_true
+        "--timings", "-t"
+            help = "Enable output of timings with warmup run"
+            action = :store_true
+        "--blas-threads", "-b"
+            help = "Set number of blas threads"
+            default = 8
+            arg_type = Int
+    end
+    return parse_args(ARGS, s)
+end
+
+"""
+    main(ARGS)
+
+QXContexts entry point
+"""
+function main(ARGS)
+    args = parse_commandline(ARGS)
+
+    dsl_file       = args["dsl"]
+    input_file     = args["input-file"]
+    param_file = args["parameter-file"]
+    output_file    = args["output-file"]
+    number_amplitudes = args["number-amplitudes"]
+    number_slices  = args["number-slices"]
+    sub_comm_size  = args["sub-comm-size"]
+    use_mpi        = args["mpi"]
+    use_gpu        = args["gpu"]
+    timings        = args["timings"]
+    blas_threads   = args["blas-threads"]
+
+    BLAS.set_num_threads(blas_threads)
+
+    results = execute(dsl_file, input_file, param_file, output_file;
+                      use_mpi=use_mpi, sub_comm_size=sub_comm_size,
+                      use_gpu=use_gpu, max_amplitudes=number_amplitudes,
+                      max_slices=number_slices,
+                      timings=timings)
+
+    if timings
+        reset_timer!()
+        results = execute(dsl_file, input_file, param_file, output_file;
+                          use_mpi=use_mpi, sub_comm_size=sub_comm_size,
+                          use_gpu=use_gpu, max_amplitudes=number_amplitudes,
+                          max_slices=number_slices,
+                          timings=timings)
+    end
+end
+
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main(ARGS)
+end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,7 +15,7 @@ makedocs(;
         "Home" => "index.md",
         "Getting Started" => "getting_started.md",
         "User's Guide" => "users_guide.md",
-        "Tutorials" => ["basics.md","features.md"],
+        "Tutorials" => ["basics.md", "circuits.md", "features.md", "distributed.md"],
         "LICENSE" => "license.md"
     ],
 )

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -38,7 +38,7 @@ push!(tnc, [1, 2], CX)
 
 ## Contracting a TensorNetworkCircuit.
 
-After creating a `TensorNetworkCircuit`, we may then want to compute the probability amplitude for a particular bitstring. To compute amplitudes for different measurement outcomes, we first set the initial state of the qubits in the circuit. This can be done using the `add_inputs!` function. For example, calling `add_inputs!(tnc, "111")` will add tensors to the tensor network which set the initial state of the circuit's qubits to the basis state labeled by "111". By default, calling `add_inputs!(tnc)` will set the initial qubit state to the "all zeros" state. 
+After creating a `TensorNetworkCircuit`, we may then want to compute the probability amplitude for a particular bitstring. To compute amplitudes for different measurement outcomes, we first set the initial state of the qubits in the circuit. This can be done using the `add_inputs!` function. For example, calling `add_inputs!(tnc, "111")` will add tensors to the tensor network which set the initial state of the circuit's qubits to the basis state labeled by "111". By default, calling `add_inputs!(tnc)` will set the initial qubit state to the "all zeros" state.
 
 ```
 # Set the initial state of the qubits to "000".
@@ -52,7 +52,7 @@ Next, we need to calculate a contraction plan for the tensor network. A contract
 plan = flow_cutter_contraction_plan(tnc; time=1)
 ```
 
-We can now compute probabiliy amplitudes using the `single_amplitude` function. Calling this function on our `TensorNetworkCircuit` object, its contraction plan and a string, indicating a product state of the qubits, will result in a copy of the circuit's tensor network being contracted according to the given contraction plan and the desired probability amplitude being returned. Note, the characters in the string give the states of the individual qubits in ascending order such that the first character in the string gives the state of the first qubit in the circuit etc. 
+We can now compute probabiliy amplitudes using the `single_amplitude` function. Calling this function on our `TensorNetworkCircuit` object, its contraction plan and a string, indicating a product state of the qubits, will result in a copy of the circuit's tensor network being contracted according to the given contraction plan and the desired probability amplitude being returned. Note, the characters in the string give the states of the individual qubits in ascending order such that the first character in the string gives the state of the first qubit in the circuit etc.
 
 ```
 # Contract the network using this plan to find the given amplitude for different outputs.
@@ -62,3 +62,7 @@ We can now compute probabiliy amplitudes using the `single_amplitude` function. 
 # The `+` and `-` characters are also supported to represent the states ("0" + "1") and ("0" - "1") respectively.
 @show single_amplitude(tnc, plan, "1++")
 ```
+
+Contracting a network with the `simple_amplitude` function will contract the network using the [QXTns](https://github.com/JuliaQX/QXTns.jl) package. This works well for small networks and for retrieving the amplitudes of one bitstring at a time.
+For more complex networks and output sampling methods we instead use the [QXContexts](https://github.com/JuliaQX/QXContexts.jl) package which provides more advanced sampling tools and supports distributed simulation as well as the use of GPU accelerators.
+The workflow for using QXContexts to contract networks is described in the [Running Distributed Simulations](distributed.md) tutorial.

--- a/docs/src/circuits.md
+++ b/docs/src/circuits.md
@@ -1,0 +1,79 @@
+# Circuits with QXZoo and YaoQX
+
+In the [introduction](basics.md) tutorial circuits are constructed by explicitly defining each of the gate matrices.
+For larger circuits this can get tedious and it is easier to construct circuits using QXZoo or to convert circuits created using [Yao.jl](https://yaoquantum.org/) to TensorNetworkCircuits.
+
+## QXZoo
+QXZoo was developed to simplify this process and provides functions for constructing commonly used circuits as well as primatives for building circuits from commonly used gate sets.
+QXTools wraps many of the functions from QXZoo to improve integration and provides a simple interface for creating [Greenberger–Horne–Zeilinger](https://arxiv.org/abs/0712.0921) (GHZ), Quantum Fourier Transform (QFT) and Random Quantum Circuits (RQC).
+
+To create a GHZ circuit with 5 qubits one would use
+
+```
+using QXTools
+circ = create_ghz_circuit(5)
+```
+This returns a QXZoo Circ struct which contains `num_qubits` and `circ_ops` data members giving the number of qubits and access to the gates respectively.
+QXTools provides `gate_qubits` and `gate_matrix` functions to simplify extracting the qubits that the gate acts upon and the matrix representation of the gate.
+
+```
+println("Circuit has $(circ.num_qubits) qubits")
+for g in circ.circ_ops
+    println("Gate acts on qubits $(gate_qubits(g))")
+    println("Matrix form $(gate_matrix(g))")
+end
+```
+
+QXTools provides the `convert_to_tnc` function which will convert a QXZoo circuit to a TensorNetworkCircuit
+
+```
+tnc = convert_to_tnc(circ)
+```
+
+The `create_qft_circuit` will create a QFT circuit when given the number of qubits.
+
+```
+circ = create_qft_circuit(5)
+```
+
+Finally the `create_rqc_circuit` creates a RQC circuit and takes arguments specifying the number of rows, columns, depth and the seed to use when sampling unitary gates. One can also specify whether or not to add a final layer of Hadamard which is sometimes ommitted.
+
+```
+circ = create_rqc_circuit(4, 4, 16, 42, final_h=true)
+```
+
+## YaoQX
+
+The [YaoQX](https://github.com/JuliaQX/YaoQX.jl) package provides a lightweight wrapper which enables circuits constructed using the [Yao](https://yaoquantum.org/) tools to be used with QXTools.
+[YaoQX](https://github.com/JuliaQX/YaoQX.jl) can be installed from the Julia package registry with
+
+```
+] add YaoQX
+```
+
+We also install [YaoBlocks](https://github.com/QuantumBFS/YaoBlocks.jl) to allow us to construct Yao circuits.
+
+```
+] add YaoBlocks
+```
+
+The following is an example of creating a simple  3 qubit GHZ circuit with YaoBlocks and converting it to a QXTools TensorNetworkCircuit.
+
+```
+using YaoQX
+using YaoBlocks
+n = 3
+circ = chain(put(1=>H), chain(map(x -> control(n, x, x+1=>X), 1:n-1)...))
+```
+
+YaoQX implements the `convert_to_tnc` function for YaoBlocks circuits so these circuits can be converted to TensorNetworkCircuits in exactly the same way that QXZoo circuits can be with
+
+```
+tnc = convert_to_tnc(circ)
+```
+
+Note that the same arguments are supported so to convert to a TensorNetworkCircuit with no input or output one can add additional keyword arguments as
+
+```
+tnc = convert_to_tnc(circ, no_input=true, no_output=true)
+```

--- a/docs/src/distributed.md
+++ b/docs/src/distributed.md
@@ -1,0 +1,187 @@
+# Running Distributed Simulations
+
+## Generating input files
+
+To use QXContexts we first generate a set of input files using the `generate_simulation_files`
+function.
+This function accepts any circuit type for which the `convert_to_tnc` function has been implemented.
+This includes QXZoo and YaoBlocks circuits, see the [Circuits with QXZoo and YaoQX](circuits.md)
+tutorial for more details on creating such circuits.
+The following example will use a 49 qubit Random Quantum Circuit (RQC) of depth 16.
+
+```
+using QXTools
+
+circ = create_rqc_circuit(7, 7, 16, 42, final_h=true)
+output_args = output_params_dict(49, 100)
+generate_simulation_files(circ, "rqc_7_7_16", time=10, output_args=output_args)
+```
+
+The above example will run the contraction finding algorithm for 10 seconds and write input files
+`rqc_7_7_16.qx`, `rqc_7_7_16.yaml` and `rqc_7_7_16.jld2`.
+By default two bonds will be sliced and the simulation files will specify that simulation should be run for 100 random bitstrings. Further details on the format and contents of these files is described in the [User Guide](users_guide.md) and further details of the slicing and output sampling options of the `generate_simulation_files` function are described in the [Miscellaneous Features](features.md) tutorial.
+
+## Running the simulation
+
+Once the input files have been generated, simulations can be run using the `bin/qxrun.jl` script which can be run directly from the command line (not the Julia REPL).
+To run a simulation using the input files generated in the example above one would use
+
+```
+julia --project bin/qxrun.jl -d rqc_7_7_16.qx -o rqc_7_7_16_output.jld2
+```
+
+This will run the simulation and write the output to the `rqc_7_7_16_output.jld2` file.
+
+To run simulations in parallel the MPI.jl package must first be installed and the `mpiexecjl` utility
+installed.
+This can be done with the following commands:
+
+```
+]add MPI
+import MPI
+MPI.install_mpiexecjl()
+```
+
+On compute clusters it is advised to use the system provided MPI installation. For more details on this see the official MPI.jl documentation [here](https://juliaparallel.github.io/MPI.jl/stable/configuration/#Using-a-system-provided-MPI).
+
+Once MPI.jl has been installed and configured the simulation example described above can be run in parallel on two processes with
+
+```
+mpiexecjl --project -n 2 julia -d rqc_7_7_16.qx -o rqc_7_7_16_output.jld2 -m
+```
+
+where the `-n 2` specifies the number of processes to use and the `-m` option enabled MPI.
+
+## Measuring the time and speedup
+
+When running the above example we would expect to see a reduction in the time taken when using more processes, however this is not what we observe in practice.
+This is due to the fact that with Julia when running code for the first time the majority of the time is taken up by compilation.
+In the above example since we are only calculating amplitudes for 10 bitstrings there are not enough computations after this compilation to observe a speedup.
+In practice for circuits of this size one would be calculating amplitudes for millions of bitstrings.
+It is also possible to reduce this startup time by compiling a custom system image as decribed in [this documentation](https://juliaqx.github.io/QXContexts.jl/dev/#Custom-system-image) for QXContexts.
+
+To see more clearly the time taken for compilation vs computation one can run the examples above using the `-t` flag. When this flag is used the simulation will be performed twice and timing information collected from each of these runs.
+(We also add `-b 1` which sets the number of BLAS threads to 1 to see clearly the effect of increasing the number of processes without changing the contention between cores that would result when threading is also used.)
+Using a single process with the following command
+
+```
+mpiexecjl --project -n 1 julia bin/qxrun.jl -d rqc_7_7_16.qx -o rqc_7_7_16_output.jld2 -m  -t -b 1
+```
+
+results in the following timing output
+
+```
+ ──────────────────────────────────────────────────────────────────────────────
+                                       Time                   Allocations
+                               ──────────────────────   ───────────────────────
+       Tot / % measured:          1127914s / 0.01%          15.5GiB / 90.5%
+
+ Section               ncalls     time   %tot     avg     alloc   %tot      avg
+ ──────────────────────────────────────────────────────────────────────────────
+ Simulation                 1    52.6s  80.5%   52.6s   13.0GiB  93.0%  13.0GiB
+ Init sampler               1    10.7s  16.3%   10.7s    759MiB  5.29%   759MiB
+   Parse input files        1    7.80s  11.9%   7.80s    562MiB  3.91%   562MiB
+   Create Context           1    1.34s  2.05%   1.34s    147MiB  1.03%   147MiB
+   Create sampler           1   73.5ms  0.11%  73.5ms   3.88MiB  0.03%  3.88MiB
+ Write results              1    2.12s  3.24%   2.12s    251MiB  1.75%   251MiB
+ ──────────────────────────────────────────────────────────────────────────────
+ ──────────────────────────────────────────────────────────────────────────────
+                                       Time                   Allocations
+                               ──────────────────────   ───────────────────────
+       Tot / % measured:            16.1s / 100%            5.95GiB / 100%
+
+ Section               ncalls     time   %tot     avg     alloc   %tot      avg
+ ──────────────────────────────────────────────────────────────────────────────
+ Simulation                 1    16.0s   100%   16.0s   5.94GiB  100%   5.94GiB
+ Init sampler               1   60.2ms  0.37%  60.2ms   11.8MiB  0.19%  11.8MiB
+   Parse input files        1   41.5ms  0.26%  41.5ms   4.80MiB  0.08%  4.80MiB
+   Create Context           1   15.6ms  0.10%  15.6ms   6.78MiB  0.11%  6.78MiB
+   Create sampler           1   69.3μs  0.00%  69.3μs   2.08KiB  0.00%  2.08KiB
+ Write results              1   1.60ms  0.01%  1.60ms   72.1KiB  0.00%  72.1KiB
+ ──────────────────────────────────────────────────────────────────────────────
+```
+
+ The first set of timings include the precompilation whereas the second set are for the computations alone.
+ From this we see that the simulation part of the code took 16 seconds when using a single process.
+ Running on two processes with
+
+```
+mpiexecjl --project -n 1 julia bin/qxrun.jl -d rqc_7_7_16.qx -o rqc_7_7_16_output.jld2 -m  -t -b 1
+```
+
+we get
+
+```
+ ──────────────────────────────────────────────────────────────────────────────
+                                       Time                   Allocations
+                               ──────────────────────   ───────────────────────
+       Tot / % measured:          1129782s / 0.01%          12.5GiB / 88.2%
+
+ Section               ncalls     time   %tot     avg     alloc   %tot      avg
+ ──────────────────────────────────────────────────────────────────────────────
+ Simulation                 1    46.5s  78.7%   46.5s   10.1GiB  91.1%  10.1GiB
+ Init sampler               1    10.5s  17.7%   10.5s    759MiB  6.72%   759MiB
+   Parse input files        1    7.62s  12.9%   7.62s    562MiB  4.97%   562MiB
+   Create Context           1    1.36s  2.31%   1.36s    147MiB  1.30%   147MiB
+   Create sampler           1   74.0ms  0.13%  74.0ms   3.88MiB  0.03%  3.88MiB
+ Write results              1    2.10s  3.57%   2.10s    251MiB  2.22%   251MiB
+ ──────────────────────────────────────────────────────────────────────────────
+ ──────────────────────────────────────────────────────────────────────────────
+                                       Time                   Allocations
+                               ──────────────────────   ───────────────────────
+       Tot / % measured:            8.53s / 100%            2.98GiB / 100%
+
+ Section               ncalls     time   %tot     avg     alloc   %tot      avg
+ ──────────────────────────────────────────────────────────────────────────────
+ Simulation                 1    8.45s  99.0%   8.45s   2.97GiB  100%   2.97GiB
+ Init sampler               1   79.9ms  0.94%  79.9ms   11.8MiB  0.39%  11.8MiB
+   Parse input files        1   38.2ms  0.45%  38.2ms   4.80MiB  0.16%  4.80MiB
+   Create Context           1   17.0ms  0.20%  17.0ms   6.78MiB  0.22%  6.78MiB
+   Create sampler           1   27.5μs  0.00%  27.5μs   2.08KiB  0.00%  2.08KiB
+ Write results              1   2.43ms  0.03%  2.43ms   72.1KiB  0.00%  72.1KiB
+ ──────────────────────────────────────────────────────────────────────────────
+```
+
+where we see that the simulation only took 8.45s, almost half the time.
+Running for four processes with
+
+```
+mpiexecjl --project -n 4 julia bin/qxrun.jl -d rqc_7_7_16.qx -o rqc_7_7_16_output.jld2 -m  -t -b 1
+```
+
+results in
+
+```
+ ──────────────────────────────────────────────────────────────────────────────
+                                       Time                   Allocations
+                               ──────────────────────   ───────────────────────
+       Tot / % measured:          1128856s / 0.01%          11.0GiB / 86.6%
+
+ Section               ncalls     time   %tot     avg     alloc   %tot      avg
+ ──────────────────────────────────────────────────────────────────────────────
+ Simulation                 1    55.6s  79.7%   55.6s   8.57GiB  89.7%  8.57GiB
+ Init sampler               1    12.0s  17.2%   12.0s    759MiB  7.76%   759MiB
+   Parse input files        1    8.58s  12.3%   8.58s    562MiB  5.74%   562MiB
+   Create Context           1    1.60s  2.30%   1.60s    147MiB  1.50%   147MiB
+   Create sampler           1   88.1ms  0.13%  88.1ms   3.88MiB  0.04%  3.88MiB
+ Write results              1    2.11s  3.03%   2.11s    251MiB  2.57%   251MiB
+ ──────────────────────────────────────────────────────────────────────────────
+ ──────────────────────────────────────────────────────────────────────────────
+                                       Time                   Allocations
+                               ──────────────────────   ───────────────────────
+       Tot / % measured:            4.63s / 100%            1.50GiB / 100%
+
+ Section               ncalls     time   %tot     avg     alloc   %tot      avg
+ ──────────────────────────────────────────────────────────────────────────────
+ Simulation                 1    4.56s  98.5%   4.56s   1.48GiB  99.2%  1.48GiB
+ Init sampler               1   68.9ms  1.49%  68.9ms   11.8MiB  0.77%  11.8MiB
+   Parse input files        1   46.3ms  1.00%  46.3ms   4.80MiB  0.31%  4.80MiB
+   Create Context           1   17.9ms  0.39%  17.9ms   6.78MiB  0.44%  6.78MiB
+   Create sampler           1   22.6μs  0.00%  22.6μs   2.08KiB  0.00%  2.08KiB
+ Write results              1   2.01ms  0.04%  2.01ms   72.1KiB  0.00%  72.1KiB
+  ──────────────────────────────────────────────────────────────────────────────
+```
+
+which shows the simulation taking 4.56s, almost half again.
+This shows that we achieve approximately linear speedup in the time taken for the actual simulation with increasing numbers of processes.
+For some scaling to larger numbers of processes see the results included in [arXiv:2110.09894](https://arxiv.org/pdf/2110.09894.pdf).

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -8,7 +8,7 @@ One feature that `QXTools` uses by default is that of [hypergraphs](https://arxi
 
 This is useful because to find an efficient contraction plan for a given tensor network, `QXTools` first creates a line graph for the network topology and then runs the FlowCutter algorithm to find a tree decompostion for that line graph which can be converted into a contraction plan. Running FlowCutter on smaller graphs often results in more efficient contraction plans, with a smaller treewidth, in a shorter amount of time.
 
-`QXTools`, together with `QXTns`, can automatically detect the diagonal structure of gate tensors in a network and create the line graph of a network while taking the hypergraph structure of the network into account. We illustrate this below by creating the line graph for a network both with and without taking the hypergraph structure into account and show that using the hypergraph structure results in a smaller line graph. Below, the line graph is represented by the [LabeledGraph](https://juliaqx.github.io/QXGraphDecompositions.jl/dev/LabeledGraph/) data structure implemented by the `QXGraphDecompositions` package. `@show`-ing this object should display the number of vertices and edges in the graph. 
+`QXTools`, together with `QXTns`, can automatically detect the diagonal structure of gate tensors in a network and create the line graph of a network while taking the hypergraph structure of the network into account. We illustrate this below by creating the line graph for a network both with and without taking the hypergraph structure into account and show that using the hypergraph structure results in a smaller line graph. Below, the line graph is represented by the [LabeledGraph](https://juliaqx.github.io/QXGraphDecompositions.jl/dev/LabeledGraph/) data structure implemented by the `QXGraphDecompositions` package. `@show`-ing this object should display the number of vertices and edges in the graph.
 
 ```
 # Create a random circuit.
@@ -38,7 +38,7 @@ For simulations that use a contraction plan with a large treewidth, it may be th
 
 The standard method for reducing the memory requirements of a simulation in exchange for greater time complexity is known as slicing. This method works by fixing the value of selected indices in the network to decompose the contraction of the network into the sum of contractions of smaller networks. For more details on this method see the section on slicing in [this](https://arxiv.org/pdf/2005.06787.pdf) article.
 
-For a given contraction plan for a tensor network, `QXTools` uses [Shutski's tree-trimming](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.102.062614), which is implemented in the package `QXGraphDecompositions` to select efficient indices of a network to slice. 
+For a given contraction plan for a tensor network, `QXTools` uses [Shutski's tree-trimming](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.102.062614), which is implemented in the package `QXGraphDecompositions` to select efficient indices of a network to slice.
 
 To find a contraction plan for a quantum circuit using flowcutter and then slice a specific number of indices using Shutski's tree trimming method, the convenience function `contraction_scheme` can be used and is demonstrated below.
 
@@ -57,7 +57,7 @@ add_input!(tnc)
 indices_to_slice, contraction_plan, metadata = contraction_scheme(tnc, 8; time=10, hypergraph=true)
 
 println("The number of indices to be sliced is ", length(indices_to_slice))
-println("The treewidth as a function of the number of indices sliced is ", 
+println("The treewidth as a function of the number of indices sliced is ",
 metadata["Slicing"]["Treewidths after slicing consecutive edges"])
 ```
 
@@ -67,7 +67,7 @@ The output of a distributed simulation run by `QXContexts` is determined by outp
 
 ### Rejection
 
-To generate random bitstrings, which are distributed as if they were measured on an ideal, noiseless quantum device running our quantum circuit, rejection sampling can be used. To create the output dictionary for rejection sampling, we can use the following keyword arguments of `output_params_dict`. 
+To generate random bitstrings, which are distributed as if they were measured on an ideal, noiseless quantum device running our quantum circuit, rejection sampling can be used. To create the output dictionary for rejection sampling, we can use the following keyword arguments of `output_params_dict`.
 
 ```
 num_qubits = 5
@@ -89,7 +89,7 @@ To compute the probability amplitudes for a list of bitstrings the list method c
 ```
 num_qubits = 5
 num_outputs = 3
-bitstrings = ["1111", "1101", "0101"] 
+bitstrings = ["1111", "1101", "0101"]
 
 output_params = output_params_dict(num_qubits, num_outputs;
                                     output_method = :List,

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -28,7 +28,7 @@ function amplitudes_uniform(qubits::Int, seed::Union{Int, Nothing}, number_ampli
 end
 
 """
-    generate_simulation_files(circ::QXZoo.Circuit.Circ,
+    generate_simulation_files(circ,
                               output_prefix::String="simulation_input",
                               number_bonds_to_slice::Int=2;
                               decompose::Bool=true,
@@ -49,7 +49,7 @@ file with the parameters to use during the simulation.
 - `decompose::Bool=true`: set if two qubit gates should be decompoed when the circuit is converted to a tensor network.
 - `kwargs`: all other kwargs are passed to `contraction_scheme` when it is called.
 """
-function generate_simulation_files(circ::QXZoo.Circuit.Circ,
+function generate_simulation_files(circ,
                                    output_prefix::String="simulation_input",
                                    number_bonds_to_slice::Int=2;
                                    decompose::Bool=true,


### PR DESCRIPTION
### Summary

Add tutorial describing circuit construction with QXZoo and conversion from YaoBlocks with YaoQX as well as running distributed simulations.

### Rationale

Tutorials demonstrating central features.

#### Implementation Details

Tutorials added as source files that are built using Documenter.jl

#### Additional notes

<hr>

***Check before merging:***

- [x] All discussions are resolved
- [x] New code is covered by appropriate tests
- [x] Tests are passing locally and on CI
- [x] The documentation is consistent with changes
- [x] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [x] Notebooks/examples not covered by unittests have been tested and updated as required
- [x] The feature branch is up-to-date with the master branch (rebase if behind)
- [x] Incremented the version string in Project.toml file
