### PR TITLE
Update deps, version number and some tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QXTools"
 uuid = "84f0eee1-10ae-40da-994b-b9d0e53829ae"
 authors = ["QuantEx team"]
-version = "0.2.5"
+version = "0.2.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -30,7 +30,7 @@ DataStructures = "0.18"
 FileIO = "1.6"
 JLD2 = "0.4"
 LightGraphs = "1.3"
-QXContexts = "0.2"
+QXContexts = "0.3"
 QXGraphDecompositions = "0.2"
 QXTns = "0.1"
 QXZoo = "0.1"

--- a/test/test_bin.jl
+++ b/test/test_bin.jl
@@ -25,7 +25,7 @@ include("../bin/prepare_rqc_simulation_files.jl")
     mktempdir() do path
         prefix = joinpath(path, "rqc_3_3_8")
         N = 20
-        args = ["-p", prefix, "-n", "$N", "--time", "30", "--output_method", "Rejection"]
+        args = ["-p", prefix, "-n", "$N", "--time", "15", "--output_method", "Rejection"]
         Logging.with_logger(Logging.NullLogger()) do # suppress logging
             main(args)
         end
@@ -40,7 +40,7 @@ include("../bin/prepare_rqc_simulation_files.jl")
     mktempdir() do path
         prefix = joinpath(path, "rqc_3_3_8")
         N = 20
-        args = ["-p", prefix, "-n", "$N", "--time", "30"]
+        args = ["-p", prefix, "-n", "$N", "--time", "15"]
         Logging.with_logger(Logging.NullLogger()) do # suppress logging
             main(args)
         end

--- a/test/test_contraction_planning.jl
+++ b/test/test_contraction_planning.jl
@@ -51,7 +51,7 @@ end
     tnc = convert_to_tnc(circ, no_input=false, no_output=true, decompose=false)
 
     # test contraction plan
-    plan = flow_cutter_contraction_plan(tnc; time=30)
+    plan = flow_cutter_contraction_plan(tnc; time=15)
     @test length(plan) == 5
 
     # test contracting the network
@@ -94,7 +94,7 @@ end
         Circuit.add_gatecall!(circ, DefaultGates.z(1))
     end
     tnc = convert_to_tnc(circ, no_input=false, no_output=false, decompose=false)
-    plan = flow_cutter_contraction_plan(tnc; time = 30, hypergraph=true)
+    plan = flow_cutter_contraction_plan(tnc; time = 15, hypergraph=true)
     @test length(plan) == 41
 end
 


### PR DESCRIPTION
### Summary

The version number was decreased to 0.2.3
The deps were updated to use latest version of QXContexts
The time allocated to flowcutter in some tests was decreased.

### Rationale

Closes #41 

#### Implementation Details

#### Additional notes

<hr>

***Check before merging:***

- [x] All discussions are resolved
- [x] New code is covered by appropriate tests
- [x] Tests are passing locally and on CI
- [x] The documentation is consistent with changes
- [x] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [x] Notebooks/examples not covered by unittests have been tested and updated as required
- [x] The feature branch is up-to-date with the master branch (rebase if behind)
- [x] Incremented the version string in Project.toml file
