### PR TITLE
Separate CI workflow for docs

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,34 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - uses: julia-actions/julia-buildpkg@v1
+      - run: |
+          julia --project -e '
+            using Pkg
+            Pkg.instantiate()
+            Pkg.add("Documenter")
+            Pkg.add("DataFrames")
+            Pkg.add("Latexify")'
+      - run: |
+          julia --project -e '
+            using Documenter: doctest
+            using QXTools
+            doctest(QXTools)'
+      - run: julia --project docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,28 +37,3 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: '1'
-      - uses: julia-actions/julia-buildpkg@v1
-      - run: |
-          julia --project -e '
-            using Pkg
-            Pkg.instantiate()
-            Pkg.add("Documenter")
-            Pkg.add("DataFrames")
-            Pkg.add("Latexify")'
-      - run: |
-          julia --project -e '
-            using Documenter: doctest
-            using QXTools
-            doctest(QXTools)'
-      - run: julia --project docs/make.jl
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QXTools"
 uuid = "84f0eee1-10ae-40da-994b-b9d0e53829ae"
 authors = ["QuantEx team"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"


### PR DESCRIPTION
### Summary

Create separate CI workflow for documentation which runs for tags

### Rationale

Workflow show run for tags so version documentation shows up.

#### Implementation Details

#### Additional notes

<hr>

***Check before merging:***

- [ ] All discussions are resolved
- [ ] New code is covered by appropriate tests
- [ ] Tests are passing locally and on CI
- [ ] The documentation is consistent with changes
- [ ] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [ ] Notebooks/examples not covered by unittests have been tested and updated as required
- [ ] The feature branch is up-to-date with the master branch (rebase if behind)
- [ ] Incremented the version string in Project.toml file
